### PR TITLE
Add missing content on the container component entrypoint for 2.1.0 docs.

### DIFF
--- a/libs/docs/src/docs/2.1.0/adding-container-component.md
+++ b/libs/docs/src/docs/2.1.0/adding-container-component.md
@@ -91,6 +91,8 @@ identified by its image.
 
 3. Container Entrypoint
 
+    Use the `command` attribute of the `container` type to modify the `entrypoint` command of the container created from the image. The availability of the `sleep` command and the support for the `infinity` argument depend on the base image used in the particular images.
+
 ## Additional Resources
 
 - [API reference](./devfile-schema)


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**What does this PR do / why we need it**:

Includes missing content on the entrypoint section of adding container components to a devfile under version 2.1.0.

**Which issue(s) this PR fixes**:

Fixes #?

N/A

**PR acceptance criteria**:

- [ ] Unit Tests
- [ ] E2E Tests
- [x] Documentation

**How to test changes / Special notes to the reviewer**:

```sh
yarn test docs
```
