### PR TITLE
docs: adding contribution guidelines and dco

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+Contributions are welcome!
+
+## Code of Conduct
+
+Before contributing to this repository for the first time, please review our project's [Code of Conduct](https://github.com/devfile/api/blob/main/CODE_OF_CONDUCT.md).
+
+## Certificate of Origin
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](DCO) file for details.
+
+In order to show your agreement with the DCO you should include at the end of the commit message,
+the following line:
+
+```
+Signed-off-by: First Lastname <email@email.com>
+```
+
+Once you set your user.name and user.email in your git config, you can sign your commit automatically with `git commit -s`.
+
+## Getting Started
+
+### Issues
+
+- Issues are tracked via the the [devfile/api](https://github.com/devfile/api) repo. Open or search for [issues](https://github.com/devfile/api/issues) with the label `area/landing-page`.
+
+- If a related issue doesn't exist, you can open a new issue using a relevant [issue form](https://github.com/devfile/api/issues/new/choose). You can tag issues with `/area landing-page`.
+
+### Pull Requests
+
+When you think the code is ready for review, create a pull request and link the issue associated with it.
+
+Owners of the repository will watch out for and review new PRs.
+
+If comments have been given in a review, they have to be addressed before merging.
+
+After addressing review comments, don’t forget to add a comment in the PR afterward, so everyone gets notified by Github and knows to re-review.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ Run `yarn install` to download dependencies.
 ## landing-page
 
 [Landing Page README](https://github.com/devfile/devfile-web/tree/main/apps/landing-page)
+
+## Contributing
+
+Please see our [contributing.md](./CONTRIBUTING.md).
+
+## License
+
+Apache License 2.0, see [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
Signed-off-by: Michael Hoang <mhoang@redhat.com>

**What does this PR do / why we need it**:

Outlines the contribution guidelines for the devfile-web repo.

**Which issue(s) this PR fixes**:

https://github.com/devfile/api/issues/772, https://github.com/devfile/api/issues/878

**PR acceptance criteria**:

- [ ] Unit Tests
- [ ] E2E Tests
- [x] Documentation

**How to test changes / Special notes to the reviewer**:
