### PR TITLE
Devfile Template Guide

### DIFF
--- a/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
@@ -21,7 +21,8 @@ build into sample templates for common use cases.
 
 1. Creating a minimal devfile
     - `schemaVersion` is the only required root element
-    - `metadata` is optional but recommend to have in your templates
+    - `metadata` is optional but recommend to have in your 
+    templates
     ```yaml {% title="Minimal Devfile" filename="devfile.yaml" %}
     schemaVersion: 2.2.0
     ```
@@ -31,103 +32,127 @@ build into sample templates for common use cases.
       name: devfile-sample
       version: 2.0.0
     ```
-2. Creating a web service
-    1. Template Metadata
+2. Creating a web service template
+    1. Template `metadata`
         - Set the template `name` and `version`
-          ```yaml {% filename="devfile.yaml" %}
+        - Set a `description` for the template
+        - Set the `projectType` and `language` to describe what
+        kind of stack is being used
+        - Set `provider` to tell who is providing this template
+        - Set `tags` to give keyword which describe the elements
+        of the stack
+        - Set `architectures` to specify the platforms support in 
+        the template
+        - For improved readability on devfile registries set `displayName` for the title to display for this template and `icon` to tie a stack icon to the template
+        ```yaml {% filename="devfile.yaml" %}
           schemaVersion: 2.2.0
           metadata:
             name: web-service
             version: 1.0.0
+            description: A web service template.
+            projectType: Go
+            language: Go
+            provider: Red Hat
+            tags: [ 'Go', 'Gin', 'pq' ]
+            architectures: [ 'amd64' ]
+            displayName: Simple Web Service
+            icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg
           ```
-    2. Setup component
+    2. Setup `components`
         - A `name` is required for a component
         - If a `container` entity is defined, a `image` must be 
         specified
-            ```yaml {% filename="devfile.yaml" %}
-            schemaVersion: 2.2.0
-            components:
-              - name: web
-                container:
-                  image: quay.io/devfile/golang:latest
-            ```
         - Though `endpoints` is optional it is needed to expose 
         the port for web connections, this requires an endpoint `name`
         and `targetPort` to expose (e.g. `8080` if that is your http 
         port)
-            ```yaml {% filename="devfile.yaml" %}
-            schemaVersion: 2.2.0
-            components:
-              - name: web
-                container:
-                  endpoints:
-                    - name: http
-                      targetPort: 8080
-                  image: quay.io/devfile/golang:latest
-            ```
-    3. Adding commands
+        - The web service might need to connect to a external 
+        database using environment variables, in this case 
+        environment variable names and values defined for the 
+        container component under `env`
+        ```yaml {% filename="devfile.yaml" %}
+        components:
+          - name: web
+            container:
+              endpoints:
+                - name: http
+                  targetPort: 8080
+              env:
+                DATABASE_HOST: db.example.com
+                DATABASE_PORT: 5432
+                DATABASE_NAME: dev
+                DATABASE_USER: devuser
+                DATABASE_PASSWORD: devpassword
+              image: quay.io/devfile/golang:latest
+        ```
+    3. Adding `commands`
         - An `id` to identify the command
         - An `exec` entity must be defined with a `commandLine` string
         and a reference to a `component`. This implies that at least 
         one component entity is defined under the root `components`
         element.
-            ```yaml {% filename="devfile.yaml" %}
-            commands:
-              - id: run
-                exec:
-                  commandLine: go run main.go
-                  component: web
-            ```
         - Set the `workingDir` to where the project source is 
         stored
-          ```yaml {% filename="devfile.yaml" %}
-          commands:
-            - id: run
-              exec:
-                commandLine: go run main.go
-                component: web
-                workingDir: ${PROJECT_SOURCE}
-          ```
         - Command groups can be used to define automation useful
         for executing a web service
-          ```yaml {% filename="devfile.yaml" %}
-          commands:
-            - id: build
-              exec:
-                commandLine: go build main.go
-                component: web
-                workingDir: ${PROJECT_SOURCE}
-                group:
-                  kind: build
-                  isDefault: true
-            - id: run
-              exec:
-                commandLine: ./main
-                component: web
-                workingDir: ${PROJECT_SOURCE}
-                group:
-                  kind: run
-                  isDefault: true
-          ```
-    4. Starter Project
         ```yaml {% filename="devfile.yaml" %}
-        starterProjects:
-          - name: web-starter
-            git:
-              remotes:
-                origin: https://github.com/devfile-samples/devfile-stack-go.git
+        commands:
+          - id: build
+            exec:
+              commandLine: go build main.go
+              component: web
+              workingDir: ${PROJECT_SOURCE}
+              group:
+                kind: build
+                isDefault: true
+          - id: run
+            exec:
+              commandLine: ./main
+              component: web
+              workingDir: ${PROJECT_SOURCE}
+              group:
+                kind: run
+                isDefault: true
         ```
+    4. Define starter projects
+        - Add a starter project under `starterProjects` which
+        includes at least a `name` and remote location, either
+        `git` or `zip`
+        - It is recommended to include a starter project 
+        description
+          ```yaml {% filename="devfile.yaml" %}
+          starterProjects:
+            - name: web-starter
+              description: A web service starting point.
+              git:
+                remotes:
+                  origin: https://github.com/devfile-samples/devfile-stack-go.git
+          ```
     ```yaml {% title="Complete Web Service Template" filename="devfile.yaml" %}
     schemaVersion: 2.2.0
     metadata:
       name: web-service
       version: 1.0.0
+      description: A web service template.
+      projectType: Go
+      language: Go
+      provider: Red Hat
+      tags: [ 'Go', 'Gin', 'pq' ]
+      architectures: [ 'amd64' ]
+      displayName: Simple Web Service
+      icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg
     components:
       - name: web
         container:
           endpoints:
             - name: http
               targetPort: 8080
+          env:
+            DATABASE_HOST: db.example.com
+            DATABASE_PORT: 5432
+            DATABASE_NAME: dev
+            DATABASE_USER: devuser
+            DATABASE_PASSWORD: devpassword
           image: quay.io/devfile/golang:latest
     commands:
       - id: build
@@ -148,6 +173,7 @@ build into sample templates for common use cases.
             isDefault: true
     starterProjects:
       - name: web-starter
+        description: A web service starting point.
         git:
           remotes:
             origin: https://github.com/devfile-samples/devfile-stack-go.git

--- a/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
@@ -181,3 +181,6 @@ build into sample templates for common use cases.
 
 
 ## Additional Resources
+
+- [API reference](./devfile-schema)
+- [Devfile resources](./resources)

--- a/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
@@ -1,6 +1,6 @@
 ---
-title: Creating Devfiles With Templates
-description: Creating Devfiles With Templates
+title: Creating devfiles with templates
+description: Creating devfiles with templates
 ---
 
 Most dev tools can utilize the devfile registry to 
@@ -19,7 +19,7 @@ building sample templates for common use cases.
 
 ## Procedure
 
-1. Creating a minimal devfile
+1. Creating a minimal devfile:
     - `schemaVersion` is the only required root element
     - `metadata` is optional but it is recommended to have in your 
     templates
@@ -32,7 +32,7 @@ building sample templates for common use cases.
       name: devfile-sample
       version: 2.0.0
     ```
-2. Creating a web service template
+2. Creating a web service template:
     1. Template `metadata`
         - Set the template `name` and `version`
         - Set a `description` for the template
@@ -59,14 +59,14 @@ building sample templates for common use cases.
             icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg
           ```
     2. Setup `components`
-        - A `name` is required for a component.
+        - A `name` is required for a component
         - If a `container` entity is defined, an `image` property must be 
-        specified.
+        specified
         - Though `endpoints` is optional, it is needed to expose 
-        the port for web connections. This requires an endpoint `name`
-        and `targetPort` to expose, for example `8080` if that is your http 
-        port.
-        - The web service might need to connect to a external 
+        the port for web connections and requires: 
+          - An endpoint `name`
+          - A `targetPort` to expose, for example, `8080` if that is your http port
+        - The web service might need to connect to an external 
         database using environment variables. In this case, define 
         environment variable names and values for the 
         container component under `env`:
@@ -88,13 +88,13 @@ building sample templates for common use cases.
     3. Adding `commands`
         - An `id` to identify the command
         - An `exec` entity must be defined with a `commandLine` string
-        and a reference to a `component`. This implies that at least 
-        one component entity is defined under the root `components`
-        element.
+        and a reference to a `component` 
+          - *This implies that at least one component entity is defined 
+          under the root `components` element*
         - The `workingDir` is set to where the project source is 
         stored
         - Command groups can be used to define automation that is useful
-        for executing a web service
+        for executing a web service:
         ```yaml
         commands:
           - id: build
@@ -119,7 +119,7 @@ building sample templates for common use cases.
         including at least a `name` and remote location, either
         `git` or `zip`
         - It is recommended to include a starter project 
-        description
+        description:
           ```yaml
           starterProjects:
             - name: web-starter

--- a/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
@@ -3,7 +3,19 @@ title: Creating Devfiles With Templates
 description: Creating Devfiles With Templates
 ---
 
+With most dev tools, you can utilize the devfile registry to 
+fetch the stacks you need to begin development of your project. 
+Sometimes however you might need to create your devfile from 
+scratch or create your own template devfile for your stack. This 
+guide will run through starting from a minimum devfile and build
+into sample templates for common use cases.
+
 ## Prerequisites
+
+- [Versions](./versions)
+- [Metadata](./metadata)
+- [Adding components](./adding-components)
+- [Adding commands](./adding-commands)
 
 ## Procedure
 

--- a/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
@@ -8,59 +8,138 @@ description: Creating Devfiles With Templates
 ## Procedure
 
 1. Creating a minimal devfile
-
-- `schemaVersion` is the only required root element
-
-```yaml {% title="Minimal Devfile" filename="devfile.yaml" %}
-schemaVersion: 2.2.0
-```
-
-2. Adding more elements to the devfile
-
-- Adding components
-    - A `name` is required for a component
-    - If a `container` entity is defined, a `image` must be specified
-    ```yaml {% title="Minimal Devfile with Container Components" filename="devfile.yaml" %}
+    - `schemaVersion` is the only required root element
+    - `metadata` is optional but recommend to have in your templates
+    ```yaml {% title="Minimal Devfile" filename="devfile.yaml" %}
     schemaVersion: 2.2.0
+    ```
+    ```yaml {% title="Minimal Devfile with Metadata" filename="devfile.yaml" %}
+    schemaVersion: 2.2.0
+    metadata:
+      name: devfile-sample
+      version: 2.0.0
+    ```
+2. Creating a web service
+    1. Template Metadata
+        - Set the template `name` and `version`
+          ```yaml {% filename="devfile.yaml" %}
+          schemaVersion: 2.2.0
+          metadata:
+            name: web-service
+            version: 1.0.0
+          ```
+    2. Setup component
+        - A `name` is required for a component
+        - If a `container` entity is defined, a `image` must be 
+        specified
+            ```yaml {% filename="devfile.yaml" %}
+            schemaVersion: 2.2.0
+            components:
+              - name: web
+                container:
+                  image: quay.io/devfile/golang:latest
+            ```
+        - Though `endpoints` is optional it is needed to expose 
+        the port for web connections, this requires an endpoint `name`
+        and `targetPort` to expose (e.g. `8080` if that is your http 
+        port)
+            ```yaml {% filename="devfile.yaml" %}
+            schemaVersion: 2.2.0
+            components:
+              - name: web
+                container:
+                  endpoints:
+                    - name: http
+                      targetPort: 8080
+                  image: quay.io/devfile/golang:latest
+            ```
+    3. Adding commands
+        - An `id` to identify the command
+        - An `exec` entity must be defined with a `commandLine` string
+        and a reference to a `component`. This implies that at least 
+        one component entity is defined under the root `components`
+        element.
+            ```yaml {% filename="devfile.yaml" %}
+            commands:
+              - id: run
+                exec:
+                  commandLine: go run main.go
+                  component: web
+            ```
+        - Set the `workingDir` to where the project source is 
+        stored
+          ```yaml {% filename="devfile.yaml" %}
+          commands:
+            - id: run
+              exec:
+                commandLine: go run main.go
+                component: web
+                workingDir: ${PROJECT_SOURCE}
+          ```
+        - Command groups can be used to define automation useful
+        for executing a web service
+          ```yaml {% filename="devfile.yaml" %}
+          commands:
+            - id: build
+              exec:
+                commandLine: go build main.go
+                component: web
+                workingDir: ${PROJECT_SOURCE}
+                group:
+                  kind: build
+                  isDefault: true
+            - id: run
+              exec:
+                commandLine: ./main
+                component: web
+                workingDir: ${PROJECT_SOURCE}
+                group:
+                  kind: run
+                  isDefault: true
+          ```
+    4. Starter Project
+        ```yaml {% filename="devfile.yaml" %}
+        starterProjects:
+          - name: web-starter
+            git:
+              remotes:
+                origin: https://github.com/devfile-samples/devfile-stack-go.git
+        ```
+    ```yaml {% title="Complete Web Service Template" filename="devfile.yaml" %}
+    schemaVersion: 2.2.0
+    metadata:
+      name: web-service
+      version: 1.0.0
     components:
       - name: web
         container:
+          endpoints:
+            - name: http
+              targetPort: 8080
           image: quay.io/devfile/golang:latest
+    commands:
+      - id: build
+        exec:
+          commandLine: go build main.go
+          component: web
+          workingDir: ${PROJECT_SOURCE}
+          group:
+            kind: build
+            isDefault: true
+      - id: run
+        exec:
+          commandLine: ./main
+          component: web
+          workingDir: ${PROJECT_SOURCE}
+          group:
+            kind: run
+            isDefault: true
+    starterProjects:
+      - name: web-starter
+        git:
+          remotes:
+            origin: https://github.com/devfile-samples/devfile-stack-go.git
     ```
-    - If a `kubernetes` or `openshift` entity is defined, a `uri` to the manifest file is required which also can be inlined
-    using `inlined` instead
-    ```yaml {% title="Minimal Devfile with Kubernetes Components" filename="devfile.yaml" %}
-    schemaVersion: 2.2.0
-    components:
-      - name: web-cluster
-        kubernetes:
-          uri: manifest.yaml
-    ```
-    - One can also define a `volume` entity with no required
-    attributes aside from the `name` of the `volume`
-    ```yaml {% title="Minimal Devfile with Volume Components" filename="devfile.yaml" %}
-    schemaVersion: 2.2.0
-    components:
-      - name: web-stor
-        volume:
-    ```
-- Adding commands
-    - An `id` to identify the command
-    - An `exec` entity must be defined with a `commandLine` string
-    and a reference to a `component`. This implies that at least 
-    one component entity is defined under the root `components`
-    element.
-```yaml {% title="Minimal Devfile with Commands" filename="devfile.yaml" %}
-schemaVersion: 2.2.0
-components:
-  - name: web
-    container:
-      image: quay.io/devfile/golang:latest
-commands:
-  - id: run
-    exec:
-      commandLine: go run main.go
-      component: web
-```
+
 
 ## Additional Resources

--- a/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
@@ -44,7 +44,7 @@ build into sample templates for common use cases.
         - Set `architectures` to specify the platforms support in 
         the template
         - For improved readability on devfile registries set `displayName` for the title to display for this template and `icon` to tie a stack icon to the template
-        ```yaml {% filename="devfile.yaml" %}
+        ```yaml
           schemaVersion: 2.2.0
           metadata:
             name: web-service
@@ -70,7 +70,7 @@ build into sample templates for common use cases.
         database using environment variables, in this case 
         environment variable names and values defined for the 
         container component under `env`
-        ```yaml {% filename="devfile.yaml" %}
+        ```yaml
         components:
           - name: web
             container:
@@ -95,7 +95,7 @@ build into sample templates for common use cases.
         stored
         - Command groups can be used to define automation useful
         for executing a web service
-        ```yaml {% filename="devfile.yaml" %}
+        ```yaml
         commands:
           - id: build
             exec:
@@ -120,7 +120,7 @@ build into sample templates for common use cases.
         `git` or `zip`
         - It is recommended to include a starter project 
         description
-          ```yaml {% filename="devfile.yaml" %}
+          ```yaml
           starterProjects:
             - name: web-starter
               description: A web service starting point.

--- a/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
@@ -3,12 +3,12 @@ title: Creating Devfiles With Templates
 description: Creating Devfiles With Templates
 ---
 
-With most dev tools, you can utilize the devfile registry to 
-fetch the stacks you need to begin development of your project. 
-Sometimes however you might need to create your devfile from 
-scratch or create your own template devfile for your stack. This 
-guide will run through starting from a minimum devfile and build
-into sample templates for common use cases.
+Most dev tools can utilize the devfile registry to 
+fetch the stacks needed to begin development on projects. 
+Sometimes however there might be a need to create a devfile 
+from scratch or create custom devfile template(s). 
+This guide will run through starting from a minimum devfile and 
+build into sample templates for common use cases.
 
 ## Prerequisites
 

--- a/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
@@ -16,6 +16,7 @@ building sample templates for common use cases.
 - [Metadata](./metadata)
 - [Adding components](./adding-components)
 - [Adding commands](./adding-commands)
+- [Defining starter projects](./defining-starter-projects)
 
 ## Procedure
 
@@ -128,6 +129,7 @@ building sample templates for common use cases.
                 remotes:
                   origin: https://github.com/devfile-samples/devfile-stack-go.git
           ```
+    5. Completing the content, the complete devfile should look like the following:
     ```yaml {% title="Complete Web Service Template" filename="devfile.yaml" %}
     schemaVersion: 2.2.0
     metadata:

--- a/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
@@ -5,10 +5,10 @@ description: Creating Devfiles With Templates
 
 Most dev tools can utilize the devfile registry to 
 fetch the stacks needed to begin development on projects. 
-Sometimes however there might be a need to create a devfile 
-from scratch or create custom devfile template(s). 
-This guide will run through starting from a minimum devfile and 
-build into sample templates for common use cases.
+Sometimes, however, you might need to create a devfile 
+from scratch or to create your own devfile template(s). 
+This guide runs through the process, starting from a minimum devfile and 
+building sample templates for common use cases.
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ build into sample templates for common use cases.
 
 1. Creating a minimal devfile
     - `schemaVersion` is the only required root element
-    - `metadata` is optional but recommend to have in your 
+    - `metadata` is optional but it is recommended to have in your 
     templates
     ```yaml {% title="Minimal Devfile" filename="devfile.yaml" %}
     schemaVersion: 2.2.0
@@ -43,7 +43,7 @@ build into sample templates for common use cases.
         of the stack
         - Set `architectures` to specify the platforms support in 
         the template
-        - For improved readability on devfile registries set `displayName` for the title to display for this template and `icon` to tie a stack icon to the template
+        - For improved readability on devfile registries, set `displayName` to the title that will be the display text for this template and `icon` to tie a stack icon to the template:
         ```yaml
           schemaVersion: 2.2.0
           metadata:
@@ -59,17 +59,17 @@ build into sample templates for common use cases.
             icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg
           ```
     2. Setup `components`
-        - A `name` is required for a component
-        - If a `container` entity is defined, a `image` must be 
-        specified
-        - Though `endpoints` is optional it is needed to expose 
-        the port for web connections, this requires an endpoint `name`
-        and `targetPort` to expose (e.g. `8080` if that is your http 
-        port)
+        - A `name` is required for a component.
+        - If a `container` entity is defined, an `image` property must be 
+        specified.
+        - Though `endpoints` is optional, it is needed to expose 
+        the port for web connections. This requires an endpoint `name`
+        and `targetPort` to expose, for example `8080` if that is your http 
+        port.
         - The web service might need to connect to a external 
-        database using environment variables, in this case 
-        environment variable names and values defined for the 
-        container component under `env`
+        database using environment variables. In this case, define 
+        environment variable names and values for the 
+        container component under `env`:
         ```yaml
         components:
           - name: web
@@ -91,9 +91,9 @@ build into sample templates for common use cases.
         and a reference to a `component`. This implies that at least 
         one component entity is defined under the root `components`
         element.
-        - Set the `workingDir` to where the project source is 
+        - The `workingDir` is set to where the project source is 
         stored
-        - Command groups can be used to define automation useful
+        - Command groups can be used to define automation that is useful
         for executing a web service
         ```yaml
         commands:
@@ -115,8 +115,8 @@ build into sample templates for common use cases.
                 isDefault: true
         ```
     4. Define starter projects
-        - Add a starter project under `starterProjects` which
-        includes at least a `name` and remote location, either
+        - Add a starter project under `starterProjects`
+        including at least a `name` and remote location, either
         `git` or `zip`
         - It is recommended to include a starter project 
         description

--- a/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
@@ -1,0 +1,54 @@
+---
+title: Creating Devfiles With Templates
+description: Creating Devfiles With Templates
+---
+
+## Prerequisites
+
+## Procedure
+
+1. Creating a minimal devfile
+
+- `schemaVersion` is the only required root element
+
+```yaml {% title="Minimal Devfile" filename="devfile.yaml" %}
+schemaVersion: 2.2.0
+```
+
+2. Adding more elements to the devfile
+
+- Adding components
+    - A `name` is required for a component
+    - If a `container` entity is defined, a `image` must be specified
++
+```yaml {% title="Minimal Devfile with Components" filename="devfile.yaml" %}
+schemaVersion: 2.2.0
+components:
+  - name: web
+    container:
+      image: quay.io/devfile/golang:latest
+```
++
+    - If a `kubernetes` entity is defined, a `uri` of a 
+
+- Adding commands
+    - An `id` to identify the command
+    - An `exec` entity must be defined with a `commandLine` string
+    and a reference to a `component`. This implies that at least 
+    one component entity is defined under the root `components`
+    element.
+
+```yaml {% title="Minimal Devfile with Commands" filename="devfile.yaml" %}
+schemaVersion: 2.2.0
+components:
+  - name: web
+    container:
+      image: quay.io/devfile/golang:latest
+commands:
+  - id: run
+    exec:
+      commandLine: go run main.go
+      component: web
+```
+
+## Additional Resources

--- a/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles-with-templates.md
@@ -20,24 +20,36 @@ schemaVersion: 2.2.0
 - Adding components
     - A `name` is required for a component
     - If a `container` entity is defined, a `image` must be specified
-+
-```yaml {% title="Minimal Devfile with Components" filename="devfile.yaml" %}
-schemaVersion: 2.2.0
-components:
-  - name: web
-    container:
-      image: quay.io/devfile/golang:latest
-```
-+
-    - If a `kubernetes` entity is defined, a `uri` of a 
-
+    ```yaml {% title="Minimal Devfile with Container Components" filename="devfile.yaml" %}
+    schemaVersion: 2.2.0
+    components:
+      - name: web
+        container:
+          image: quay.io/devfile/golang:latest
+    ```
+    - If a `kubernetes` or `openshift` entity is defined, a `uri` to the manifest file is required which also can be inlined
+    using `inlined` instead
+    ```yaml {% title="Minimal Devfile with Kubernetes Components" filename="devfile.yaml" %}
+    schemaVersion: 2.2.0
+    components:
+      - name: web-cluster
+        kubernetes:
+          uri: manifest.yaml
+    ```
+    - One can also define a `volume` entity with no required
+    attributes aside from the `name` of the `volume`
+    ```yaml {% title="Minimal Devfile with Volume Components" filename="devfile.yaml" %}
+    schemaVersion: 2.2.0
+    components:
+      - name: web-stor
+        volume:
+    ```
 - Adding commands
     - An `id` to identify the command
     - An `exec` entity must be defined with a `commandLine` string
     and a reference to a `component`. This implies that at least 
     one component entity is defined under the root `components`
     element.
-
 ```yaml {% title="Minimal Devfile with Commands" filename="devfile.yaml" %}
 schemaVersion: 2.2.0
 components:

--- a/libs/docs/src/docs/2.2.1-alpha/create-devfiles-with-templates.md
+++ b/libs/docs/src/docs/2.2.1-alpha/create-devfiles-with-templates.md
@@ -1,0 +1,188 @@
+---
+title: Creating devfiles with templates
+description: Creating devfiles with templates
+---
+
+Most dev tools can utilize the devfile registry to 
+fetch the stacks needed to begin development on projects. 
+Sometimes, however, you might need to create a devfile 
+from scratch or to create your own devfile template(s). 
+This guide runs through the process, starting from a minimum devfile and 
+building sample templates for common use cases.
+
+## Prerequisites
+
+- [Versions](./versions)
+- [Metadata](./metadata)
+- [Adding components](./adding-components)
+- [Adding commands](./adding-commands)
+- [Defining starter projects](./defining-starter-projects)
+
+## Procedure
+
+1. Creating a minimal devfile:
+    - `schemaVersion` is the only required root element
+    - `metadata` is optional but it is recommended to have in your 
+    templates
+    ```yaml {% title="Minimal Devfile" filename="devfile.yaml" %}
+    schemaVersion: 2.2.1
+    ```
+    ```yaml {% title="Minimal Devfile with Metadata" filename="devfile.yaml" %}
+    schemaVersion: 2.2.1
+    metadata:
+      name: devfile-sample
+      version: 2.0.0
+    ```
+2. Creating a web service template:
+    1. Template `metadata`
+        - Set the template `name` and `version`
+        - Set a `description` for the template
+        - Set the `projectType` and `language` to describe what
+        kind of stack is being used
+        - Set `provider` to tell who is providing this template
+        - Set `tags` to give keyword which describe the elements
+        of the stack
+        - Set `architectures` to specify the platforms support in 
+        the template
+        - For improved readability on devfile registries, set `displayName` to the title that will be the display text for this template and `icon` to tie a stack icon to the template:
+        ```yaml
+          schemaVersion: 2.2.1
+          metadata:
+            name: web-service
+            version: 1.0.0
+            description: A web service template.
+            projectType: Go
+            language: Go
+            provider: Red Hat
+            tags: [ 'Go', 'Gin', 'pq' ]
+            architectures: [ 'amd64' ]
+            displayName: Simple Web Service
+            icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg
+          ```
+    2. Setup `components`
+        - A `name` is required for a component
+        - If a `container` entity is defined, an `image` property must be 
+        specified
+        - Though `endpoints` is optional, it is needed to expose 
+        the port for web connections and requires: 
+          - An endpoint `name`
+          - A `targetPort` to expose, for example, `8080` if that is your http port
+        - The web service might need to connect to an external 
+        database using environment variables. In this case, define 
+        environment variable names and values for the 
+        container component under `env`:
+        ```yaml
+        components:
+          - name: web
+            container:
+              endpoints:
+                - name: http
+                  targetPort: 8080
+              env:
+                DATABASE_HOST: db.example.com
+                DATABASE_PORT: 5432
+                DATABASE_NAME: dev
+                DATABASE_USER: devuser
+                DATABASE_PASSWORD: devpassword
+              image: quay.io/devfile/golang:latest
+        ```
+    3. Adding `commands`
+        - An `id` to identify the command
+        - An `exec` entity must be defined with a `commandLine` string
+        and a reference to a `component` 
+          - *This implies that at least one component entity is defined 
+          under the root `components` element*
+        - The `workingDir` is set to where the project source is 
+        stored
+        - Command groups can be used to define automation that is useful
+        for executing a web service:
+        ```yaml
+        commands:
+          - id: build
+            exec:
+              commandLine: go build main.go
+              component: web
+              workingDir: ${PROJECT_SOURCE}
+              group:
+                kind: build
+                isDefault: true
+          - id: run
+            exec:
+              commandLine: ./main
+              component: web
+              workingDir: ${PROJECT_SOURCE}
+              group:
+                kind: run
+                isDefault: true
+        ```
+    4. Define starter projects
+        - Add a starter project under `starterProjects`
+        including at least a `name` and remote location, either
+        `git` or `zip`
+        - It is recommended to include a starter project 
+        description:
+          ```yaml
+          starterProjects:
+            - name: web-starter
+              description: A web service starting point.
+              git:
+                remotes:
+                  origin: https://github.com/devfile-samples/devfile-stack-go.git
+          ```
+    5. Completing the content, the complete devfile should look like the following:
+    ```yaml {% title="Complete Web Service Template" filename="devfile.yaml" %}
+    schemaVersion: 2.2.1
+    metadata:
+      name: web-service
+      version: 1.0.0
+      description: A web service template.
+      projectType: Go
+      language: Go
+      provider: Red Hat
+      tags: [ 'Go', 'Gin', 'pq' ]
+      architectures: [ 'amd64' ]
+      displayName: Simple Web Service
+      icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg
+    components:
+      - name: web
+        container:
+          endpoints:
+            - name: http
+              targetPort: 8080
+          env:
+            DATABASE_HOST: db.example.com
+            DATABASE_PORT: 5432
+            DATABASE_NAME: dev
+            DATABASE_USER: devuser
+            DATABASE_PASSWORD: devpassword
+          image: quay.io/devfile/golang:latest
+    commands:
+      - id: build
+        exec:
+          commandLine: go build main.go
+          component: web
+          workingDir: ${PROJECT_SOURCE}
+          group:
+            kind: build
+            isDefault: true
+      - id: run
+        exec:
+          commandLine: ./main
+          component: web
+          workingDir: ${PROJECT_SOURCE}
+          group:
+            kind: run
+            isDefault: true
+    starterProjects:
+      - name: web-starter
+        description: A web service starting point.
+        git:
+          remotes:
+            origin: https://github.com/devfile-samples/devfile-stack-go.git
+    ```
+
+
+## Additional Resources
+
+- [API reference](./devfile-schema)
+- [Devfile resources](./resources)

--- a/libs/docs/src/navigation/2.2.0.yaml
+++ b/libs/docs/src/navigation/2.2.0.yaml
@@ -60,7 +60,7 @@
       href: ./defining-starter-projects      
     - title: Referring to a parent devfile
       href: ./referring-to-a-parent-devfile
-    - title: Creating Devfiles With Templates
+    - title: Creating devfiles with templates
       href: ./create-devfiles-with-templates
 - title: API reference
   links:

--- a/libs/docs/src/navigation/2.2.0.yaml
+++ b/libs/docs/src/navigation/2.2.0.yaml
@@ -60,6 +60,8 @@
       href: ./defining-starter-projects      
     - title: Referring to a parent devfile
       href: ./referring-to-a-parent-devfile
+    - title: Creating Devfiles With Templates
+      href: ./create-devfiles-with-templates
 - title: API reference
   links:
     - title: Devfile schema

--- a/libs/docs/src/navigation/2.2.1-alpha.yaml
+++ b/libs/docs/src/navigation/2.2.1-alpha.yaml
@@ -60,6 +60,8 @@
       href: ./defining-starter-projects      
     - title: Referring to a parent devfile
       href: ./referring-to-a-parent-devfile
+    - title: Creating devfiles with templates
+      href: ./create-devfiles-with-templates
 - title: API reference
   links:
     - title: Devfile schema


### PR DESCRIPTION
**What does this PR do / why we need it**:

Adds the Devfile Template Guide to demonstration and instruct users on creating devfiles from the ground up for practical development environments. The initial instruction shows step by step process of building a devfile for a web service project.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#911

**PR acceptance criteria**:

- [ ] Unit Tests
- [ ] E2E Tests
- [x] Documentation

**How to test changes / Special notes to the reviewer**:
