### PR TITLE
Added a trailing slash for the registry viewer static files

### DIFF
--- a/apps/registry-viewer/config.ts
+++ b/apps/registry-viewer/config.ts
@@ -17,5 +17,5 @@
 import type { DevfileRegistry } from '@devfile-web/core';
 
 export const devfileRegistries: DevfileRegistry[] = [
-  { name: 'Devfile registry', link: 'https://registry.devfile.io' },
+  { name: 'Community', link: 'https://registry.devfile.io' },
 ];

--- a/apps/registry-viewer/next.config.js
+++ b/apps/registry-viewer/next.config.js
@@ -33,6 +33,7 @@ const nextConfig = {
   pageExtensions: ['js', 'jsx', 'tsx', 'md'],
   reactStrictMode: true,
   swcMinify: true,
+  trailingSlash: true,
   images: {
     loader: 'akamai',
     path: '',


### PR DESCRIPTION
Signed-off-by: Paul Schultz <pschultz@pobox.com>

**What does this PR do / why we need it**:

Adds a trailing slash for the registry viewer static files. This will make it easier for server static files on registry-support.

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

**How to test changes / Special notes to the reviewer**:
