### PR TITLE
Removed 2.2.0-alpha references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
-**What does this PR do / why we need it**:
+# What does this PR do / why we need it
 
-**Which issue(s) this PR fixes**:
+## Which issue(s) does this PR fix
 
 Fixes #?
 
-**PR acceptance criteria**:
+## PR acceptance criteria
 
 - [ ] Unit Tests
 - [ ] E2E Tests
 - [ ] Documentation
 
-**How to test changes / Special notes to the reviewer**:
+## How to test changes / Special notes to the reviewer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ contribution. See the [DCO](DCO) file for details.
 In order to show your agreement with the DCO you should include at the end of the commit message,
 the following line:
 
-```
-Signed-off-by: First Lastname <email@email.com>
+```console
+Signed-off-by: Firstname Lastname <email@email.com>
 ```
 
 Once you set your user.name and user.email in your git config, you can sign your commit automatically with `git commit -s`.

--- a/libs/docs/src/devfile-schemas/2.2.0.json
+++ b/libs/docs/src/devfile-schemas/2.2.0.json
@@ -1,7 +1,7 @@
 {
   "description": "Devfile describes the structure of a cloud-native devworkspace and development environment.",
   "type": "object",
-  "title": "Devfile schema - Version 2.2.0-alpha",
+  "title": "Devfile schema - Version 2.2.0",
   "required": [
     "schemaVersion"
   ],


### PR DESCRIPTION
Signed-off-by: Paul Schultz <pschultz@pobox.com>

**What does this PR do / why we need it**:

Removes 2.2.0-alpha references

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/974

**PR acceptance criteria**:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

**How to test changes / Special notes to the reviewer**:
