### PR TITLE
Revisions to `build_viewer.sh`

### DIFF
--- a/scripts/build_viewer.sh
+++ b/scripts/build_viewer.sh
@@ -14,7 +14,10 @@
 
 #!/usr/bin/env bash
 
-docker build -t registry-viewer . \
+ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR=$ABSOLUTE_PATH/..
+
+docker build -t registry-viewer $BUILD_DIR \
     --build-arg PROJECT_NAME=registry-viewer \
     --build-arg SITE_URL=${SITE_URL:-"https://registry.stage.devfile.io/viewer"} \
     --build-arg NEXT_PUBLIC_BASE_PATH=${NEXT_PUBLIC_BASE_PATH:-"/viewer"} \

--- a/scripts/build_viewer.sh
+++ b/scripts/build_viewer.sh
@@ -17,7 +17,7 @@
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR=$ABSOLUTE_PATH/..
 
-docker build -t registry-viewer $BUILD_DIR \
+docker build --no-cache -t registry-viewer $BUILD_DIR \
     --build-arg PROJECT_NAME=registry-viewer \
     --build-arg SITE_URL=${SITE_URL:-"https://registry.stage.devfile.io/viewer"} \
     --build-arg NEXT_PUBLIC_BASE_PATH=${NEXT_PUBLIC_BASE_PATH:-"/viewer"} \


### PR DESCRIPTION
# What does this PR do / why we need it

This PR provides two revisions the `build_viewer.sh` file:
- Defines build directory as the base of devfile-web even if it is not the PWD
- The `docker build` no longer caches steps

## Which issue(s) does this PR fix

Fixes #?

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
