### PR TITLE
docs: removing references to sparseCheckoutDir

### DIFF
--- a/libs/docs/src/docs/2.0.0/adding-projects.md
+++ b/libs/docs/src/docs/2.0.0/adding-projects.md
@@ -104,28 +104,6 @@ This section describes how to add one or more projects to a devfile.
               revision: develop
     ```
 
-5. For each project, define the optional `sparseCheckoutDir` attribute
-    to populate the project sparsely with selected directories.
-
-    {% callout title="Note!" %}
-    - Set to `/my-module/` to create only the root `my-module`
-        directory (and its content).
-
-    - Omit the leading slash (`my-module/`) to create all `my-module`
-        directories that exist in the project. Including, for example,
-        `/addons/my-module/`.
-
-        The trailing slash indicates that only directories with the
-        given name (including their content) are created.
-
-    - Use wildcards to specify more than one directory name. For
-        example, setting `module-*` checks out all directories of the
-        given project that start with `module-`.
-
-    For more information, see [Sparse checkout in Git
-    documentation](https://git-scm.com/docs/git-read-tree#_sparse_checkout).
-    {% /callout %}
-
 ## Additional Resources
 
 - [API reference](./devfile-schema)

--- a/libs/docs/src/docs/2.1.0/adding-projects.md
+++ b/libs/docs/src/docs/2.1.0/adding-projects.md
@@ -97,28 +97,6 @@ This section describes how to add one or more projects to a devfile.
               revision: develop
     ```
 
-5. For each project, define the optional `sparseCheckoutDir` attribute
-    to populate the project sparsely with selected directories.
-
-    {% callout title="Note!" %}
-    - Set to `/my-module/` to create only the root `my-module`
-        directory (and its content).
-
-    - Omit the leading slash (`my-module/`) to create all `my-module`
-        directories that exist in the project. Including, for example,
-        `/addons/my-module/`.
-
-        The trailing slash indicates that only directories with the
-        given name (including their content) are created.
-
-    - Use wildcards to specify more than one directory name. For
-        example, setting `module-*` checks out all directories of the
-        given project that start with `module-`.
-
-    For more information, see [Sparse checkout in Git
-    documentation](https://git-scm.com/docs/git-read-tree#_sparse_checkout).
-    {% /callout %}
-
 ## Additional resources
 
 - [API reference](./devfile-schema)

--- a/libs/docs/src/docs/2.2.0/adding-projects.md
+++ b/libs/docs/src/docs/2.2.0/adding-projects.md
@@ -156,28 +156,6 @@ following tables for project properties in a devfile:
               revision: develop
     ```
 
-5. For each project, define the optional `sparseCheckoutDir` attribute
-    to populate the project sparsely with selected directories.
-
-    {% callout title="Note!" %}
-    - Set the project to `/my-module/` to create only the root
-      `my-module` directory along with its content.
-
-    - Omit the leading slash (`my-module/`) to create all `my-module`
-      directories that exist in the project. Including, for example,
-      `/addons/my-module/`.
-
-      - Add a trailing slash to create only directories with the
-        given name (and its content).
-
-    - Use wildcards to specify more than one directory name. For
-      example, setting `module-*` checks out all directories of the
-      given project that start with `module-`.
-
-    For more information, see [Sparse checkout in Git
-    documentation](https://git-scm.com/docs/git-read-tree#_sparse_checkout).
-    {% /callout %}
-
 ## Additional Resources
 
 - [Api reference](./devfile-schema)

--- a/libs/docs/src/docs/2.2.1-alpha/adding-projects.md
+++ b/libs/docs/src/docs/2.2.1-alpha/adding-projects.md
@@ -156,28 +156,6 @@ following tables for project properties in a devfile:
               revision: develop
     ```
 
-5. For each project, define the optional `sparseCheckoutDir` attribute
-    to populate the project sparsely with selected directories.
-
-    {% callout title="Note!" %}
-    - Set the project to `/my-module/` to create only the root
-      `my-module` directory along with its content.
-
-    - Omit the leading slash (`my-module/`) to create all `my-module`
-      directories that exist in the project. Including, for example,
-      `/addons/my-module/`.
-
-      - Add a trailing slash to create only directories with the
-        given name (and its content).
-
-    - Use wildcards to specify more than one directory name. For
-      example, setting `module-*` checks out all directories of the
-      given project that start with `module-`.
-
-    For more information, see [Sparse checkout in Git
-    documentation](https://git-scm.com/docs/git-read-tree#_sparse_checkout).
-    {% /callout %}
-
 ## Additional Resources
 
 - [Api reference](./devfile-schema)


### PR DESCRIPTION
Signed-off-by: Michael Hoang <mhoang@redhat.com>

## What does this PR do / why we need it

Removes all references to `sparseCheckoutDir` because it has been removed from the api

## Which issue(s) does this PR fix

Fixes https://github.com/devfile/api/issues/1011

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
