### PR TITLE
Update introduction links

### DIFF
--- a/libs/docs/src/docs/no-version/developing-with-devfiles.md
+++ b/libs/docs/src/docs/no-version/developing-with-devfiles.md
@@ -32,7 +32,7 @@ Get started with [JetBrains Space Cloud Dev Environments](https://blog.jetbrains
 
 - [Eclipse Che](https://medium.com/eclipse-che-blog/devfile-v2-and-ide-plug-ins-in-eclipse-che-7a560ae724b1)
 
-- [OpenShift Dev Console](https://github.com/openshift/console)
+- [OpenShift Dev Console](https://github.com/openshift/console#openshift-console)
 
 - [VSCode OpenShift Toolkit](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-openshift-connector)
 

--- a/libs/docs/src/docs/no-version/how-to-work-with-devfiles.md
+++ b/libs/docs/src/docs/no-version/how-to-work-with-devfiles.md
@@ -5,7 +5,7 @@ description: How to work with devfiles
 
 - To access the devfile stacks so you can begin creating container
     workspaces, see [devfile registry
-    stacks](https://github.com/devfile/registry/tree/main/stacks).
+    stacks](https://registry.devfile.io/viewer).
 
 - To write a devfile stack so you can begin using devfiles in your
     application development, see [overview](./overview).


### PR DESCRIPTION
## What does this PR do / why we need it
It simply updates two links in the introduction:
* First one in the [how to work with the devfiles section](https://devfile.io/docs/2.0.0/how-to-work-with-devfiles) the **devfile registry stacks** link points [here](https://github.com/devfile/registry/tree/main/stacks). IMO it should point to the registry-viewer.
* Secondly the link to the openshif console, I think it would be better if it pointed to the Readme file.

## Which issue(s) does this PR fix

Fixes #?

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

## How to test changes / Special notes to the reviewer
