### PR TITLE
reorganizing docs navigation for 2.2.0 and 2.2.1

### DIFF
--- a/apps/registry-viewer/navigation.ts
+++ b/apps/registry-viewer/navigation.ts
@@ -45,6 +45,7 @@ export const footerNavigation: FooterNavigation = {
     { name: 'Cloud Native Computing Foundation', href: 'https://www.cncf.io' },
     { name: 'Registry', href: '/' },
     { name: 'Documentation', href: `https://devfile.io/docs/${defaultVersion}/what-is-a-devfile` },
+    { name: 'Community', href: `https://devfile.io/docs/${defaultVersion}/community` },
   ],
   social: [
     {

--- a/libs/docs/src/docs/2.2.0/adding-a-container-component.md
+++ b/libs/docs/src/docs/2.2.0/adding-a-container-component.md
@@ -121,12 +121,12 @@ configuration of a container in a workspace using the `container` component type
     `infinity` argument depend on the base image used in the particular
     images.
 
-    All tools will respect the specified `command`. When `command` 
-    is not defined, the container will use the default from the 
-    image specified. When `command` is defined, it will override 
-    the one present in the image as intended. Either the 
-    `command` defined by the image or by the container component 
-    within the devfile must be non-terminating, such as the case 
+    All tools will respect the specified `command`. When `command`
+    is not defined, the container will use the default from the
+    image specified. When `command` is defined, it will override
+    the one present in the image as intended. Either the
+    `command` defined by the image or by the container component
+    within the devfile must be non-terminating, such as the case
     of setting `command` to `sleep` with the `infinity` argument.
 
     ```yaml {% filename="devfile.yaml" %}

--- a/libs/docs/src/docs/2.2.0/authoring-overview.md
+++ b/libs/docs/src/docs/2.2.0/authoring-overview.md
@@ -1,0 +1,35 @@
+---
+title: Overview
+description: Authoring devfile - Overview
+---
+
+## Creating a minimal devfile
+
+The `schemaVersion` attribute is mandatory in a devfile.
+
+### Procedure
+
+- Define the `schemaVersion` attribute in the devfile and specify a static name for the workspace with the `name` attribute.
+
+    ```yaml {% title="Minimal devfile with schema version and name" filename="devfile.yaml" %}
+    schemaVersion: <version>
+    metadata:
+      name: devfile-sample
+      version: 0.0.1
+    ```
+
+## Adding to a minimal devfile
+
+See the following documents to help you add to the minimal devfile to suit your development needs:
+
+- [Adding projects](./adding-projects)
+
+- [Adding components](./adding-components)
+
+- [Adding commands](./adding-commands)
+
+- [Defining variables](./defining-variables)
+
+- [Defining attributes](./defining-attributes)
+
+- [Referring to a parent devfile in a devfile](./referring-to-a-parent-devfile)

--- a/libs/docs/src/docs/2.2.0/create-devfiles.md
+++ b/libs/docs/src/docs/2.2.0/create-devfiles.md
@@ -1,6 +1,6 @@
 ---
-title: Creating devfiles with templates
-description: Creating devfiles with templates
+title: Creating devfiles
+description: Creating devfiles
 ---
 
 Most dev tools can utilize the devfile registry to 
@@ -25,10 +25,10 @@ building sample templates for common use cases.
     - `metadata` is optional but it is recommended to have in your 
     templates
     ```yaml {% title="Minimal Devfile" filename="devfile.yaml" %}
-    schemaVersion: 2.2.0
+    schemaVersion: <version>
     ```
     ```yaml {% title="Minimal Devfile with Metadata" filename="devfile.yaml" %}
-    schemaVersion: 2.2.0
+    schemaVersion: <version>
     metadata:
       name: devfile-sample
       version: 2.0.0
@@ -46,7 +46,7 @@ building sample templates for common use cases.
         the template
         - For improved readability on devfile registries, set `displayName` to the title that will be the display text for this template and `icon` to tie a stack icon to the template:
         ```yaml
-          schemaVersion: 2.2.0
+          schemaVersion: <version>
           metadata:
             name: web-service
             version: 1.0.0
@@ -131,7 +131,7 @@ building sample templates for common use cases.
           ```
     5. Completing the content, the complete devfile should look like the following:
     ```yaml {% title="Complete Web Service Template" filename="devfile.yaml" %}
-    schemaVersion: 2.2.0
+    schemaVersion: <version>
     metadata:
       name: web-service
       version: 1.0.0

--- a/libs/docs/src/docs/2.2.0/defining-attributes.md
+++ b/libs/docs/src/docs/2.2.0/defining-attributes.md
@@ -44,17 +44,17 @@ Attributes can be defined at the top level of the devfile, or in the following o
     ----
     ```
 
-2. Define a custom attribute in the `metadata` object.
+2. Define a custom attribute at the devfile level.
 
     When no editor is specified, a default editor is provided. To represent this user-defined example, use the `editorFree` attribute as shown in the following example:
 
     ```yaml {% title="A devfile without an editor" %}
     ----
     schemaVersion: 2.2.0
+    attributes:
+        editorFree: true
     metadata:
       name: petclinic-dev-environment
-      attributes:
-        editorFree: true
     components:
       - name: myapp
         kubernetes:

--- a/libs/docs/src/docs/2.2.0/innerloop-vs-outerloop.md
+++ b/libs/docs/src/docs/2.2.0/innerloop-vs-outerloop.md
@@ -19,7 +19,7 @@ In a devfile spec, there are two scopes of deployment: innerloop and outerloop. 
     - This example will use `nodejs-18` UBI image
 
     ```yaml
-    schemaVersion: 2.2.0
+    schemaVersion: <version>
     metadata:
       name: nodejs
     components:
@@ -119,7 +119,7 @@ In a devfile spec, there are two scopes of deployment: innerloop and outerloop. 
     ```
 
 ```yaml {% title="Final innerloop devfile" filename="devfile.yaml" %}
-schemaVersion: 2.2.0
+schemaVersion: <version>
 metadata:
   name: nodejs
 components:
@@ -255,7 +255,7 @@ The component and commands here allow the developer to build, run, debug, and te
     ```
 
 ```yaml {% title="Final outerloop devfile" filename="devfile.yaml" %}
-schemaVersion: 2.2.0
+schemaVersion: <version>
 metadata:
   name: nodejs
 components:

--- a/libs/docs/src/docs/2.2.0/overriding-pod-and-container-attributes.md
+++ b/libs/docs/src/docs/2.2.0/overriding-pod-and-container-attributes.md
@@ -14,7 +14,7 @@ This attribute can be defined at the component level.
 ### Procedure
 1. Specify "container-overrides" at the component level.
     ```yaml {% title="Specify container-overrides to override security context for container at component level" filename="devfile.yaml" %}
-    schemaVersion: 2.2.0
+    schemaVersion: <version>
     components:
       - name: maven
         attributes:
@@ -43,7 +43,7 @@ This attribute can be defined at the component and devfile attributes levels. If
 ### Procedure
 1. Specify "pod-overrides" at the component level.
     ```yaml {% title="Specify pod-overrides to override security context for container at component level" filename="devfile.yaml" %}
-    schemaVersion: 2.2.0
+    schemaVersion: <version>
     components:
       - name: maven
         attributes:
@@ -56,7 +56,7 @@ This attribute can be defined at the component and devfile attributes levels. If
 
 2. Specify "pod-overrides" at the devfile attributes level. It will be defined as a top-level attribute.
     ```yaml {% title="Specify pod-overrides to override resources for container at the devfile level" filename="devfile.yaml" %}
-    schemaVersion: 2.2.0
+    schemaVersion: <version>
     attributes:
       pod-overrides:
         spec:

--- a/libs/docs/src/docs/2.2.0/packaging-devfile.md
+++ b/libs/docs/src/docs/2.2.0/packaging-devfile.md
@@ -5,7 +5,7 @@ description: Packaging devfile
 
 ## Creating a devfile
 
-To create a devfile, you can [start from scratch](./create-devfiles-with-templates) or use the [public community devfile registry](https://registry.devfile.io/viewer) to find predefined stacks for popular languages and frameworks. Once you have a devfile, save it as `.devfile.yaml` to your application’s root directory.
+To create a devfile, you can [start from scratch](./create-devfiles) or use the [public community devfile registry](https://registry.devfile.io/viewer) to find predefined stacks for popular languages and frameworks. Once you have a devfile, save it as `.devfile.yaml` to your application’s root directory.
 
 ## Resources to include with your devfile
 

--- a/libs/docs/src/docs/2.2.1-alpha/authoring-overview.md
+++ b/libs/docs/src/docs/2.2.1-alpha/authoring-overview.md
@@ -1,0 +1,35 @@
+---
+title: Overview
+description: Authoring devfile - Overview
+---
+
+## Creating a minimal devfile
+
+The `schemaVersion` attribute is mandatory in a devfile.
+
+### Procedure
+
+- Define the `schemaVersion` attribute in the devfile and specify a static name for the workspace with the `name` attribute.
+
+    ```yaml {% title="Minimal devfile with schema version and name" filename="devfile.yaml" %}
+    schemaVersion: <version>
+    metadata:
+      name: devfile-sample
+      version: 0.0.1
+    ```
+
+## Adding to a minimal devfile
+
+See the following documents to help you add to the minimal devfile to suit your development needs:
+
+- [Adding projects](./adding-projects)
+
+- [Adding components](./adding-components)
+
+- [Adding commands](./adding-commands)
+
+- [Defining variables](./defining-variables)
+
+- [Defining attributes](./defining-attributes)
+
+- [Referring to a parent devfile in a devfile](./referring-to-a-parent-devfile)

--- a/libs/docs/src/docs/2.2.1-alpha/create-devfiles.md
+++ b/libs/docs/src/docs/2.2.1-alpha/create-devfiles.md
@@ -1,6 +1,6 @@
 ---
-title: Creating devfiles with templates
-description: Creating devfiles with templates
+title: Creating devfiles
+description: Creating devfiles
 ---
 
 Most dev tools can utilize the devfile registry to 
@@ -25,10 +25,10 @@ building sample templates for common use cases.
     - `metadata` is optional but it is recommended to have in your 
     templates
     ```yaml {% title="Minimal Devfile" filename="devfile.yaml" %}
-    schemaVersion: 2.2.1
+    schemaVersion: <version>
     ```
     ```yaml {% title="Minimal Devfile with Metadata" filename="devfile.yaml" %}
-    schemaVersion: 2.2.1
+    schemaVersion: <version>
     metadata:
       name: devfile-sample
       version: 2.0.0
@@ -46,7 +46,7 @@ building sample templates for common use cases.
         the template
         - For improved readability on devfile registries, set `displayName` to the title that will be the display text for this template and `icon` to tie a stack icon to the template:
         ```yaml
-          schemaVersion: 2.2.1
+          schemaVersion: <version>
           metadata:
             name: web-service
             version: 1.0.0
@@ -131,7 +131,7 @@ building sample templates for common use cases.
           ```
     5. Completing the content, the complete devfile should look like the following:
     ```yaml {% title="Complete Web Service Template" filename="devfile.yaml" %}
-    schemaVersion: 2.2.1
+    schemaVersion: <version>
     metadata:
       name: web-service
       version: 1.0.0

--- a/libs/docs/src/docs/2.2.1-alpha/innerloop-vs-outerloop.md
+++ b/libs/docs/src/docs/2.2.1-alpha/innerloop-vs-outerloop.md
@@ -19,7 +19,7 @@ In a devfile spec, there are two scopes of deployment: innerloop and outerloop. 
     - This example will use `nodejs-18` UBI image
 
     ```yaml
-    schemaVersion: 2.2.1-alpha
+    schemaVersion: <version>
     metadata:
       name: nodejs
     components:
@@ -119,7 +119,7 @@ In a devfile spec, there are two scopes of deployment: innerloop and outerloop. 
     ```
 
 ```yaml {% title="Final innerloop devfile" filename="devfile.yaml" %}
-schemaVersion: 2.2.1-alpha
+schemaVersion: <version>
 metadata:
   name: nodejs
 components:
@@ -255,7 +255,7 @@ The component and commands here allow the developer to build, run, debug, and te
     ```
 
 ```yaml {% title="Final outerloop devfile" filename="devfile.yaml" %}
-schemaVersion: 2.2.1-alpha
+schemaVersion: <version>
 metadata:
   name: nodejs
 components:

--- a/libs/docs/src/docs/2.2.1-alpha/overriding-pod-and-container-attributes.md
+++ b/libs/docs/src/docs/2.2.1-alpha/overriding-pod-and-container-attributes.md
@@ -14,7 +14,7 @@ This attribute can be defined at the component level.
 ### Procedure
 1. Specify "container-overrides" at the component level.
     ```yaml {% title="Specify container-overrides to override security context for container at component level" filename="devfile.yaml" %}
-    schemaVersion: 2.2.1
+    schemaVersion: <version>
     components:
       - name: maven
         attributes:
@@ -43,7 +43,7 @@ This attribute can be defined at the component and devfile attributes levels. If
 ### Procedure
 1. Specify "pod-overrides" at the component level.
     ```yaml {% title="Specify pod-overrides to override security context for container at component level" filename="devfile.yaml" %}
-    schemaVersion: 2.2.1
+    schemaVersion: <version>
     components:
       - name: maven
         attributes:
@@ -56,7 +56,7 @@ This attribute can be defined at the component and devfile attributes levels. If
 
 2. Specify "pod-overrides" at the devfile attributes level. It will be defined as a top-level attribute.
     ```yaml {% title="Specify pod-overrides to override resources for container at the devfile level" filename="devfile.yaml" %}
-    schemaVersion: 2.2.1
+    schemaVersion: <version>
     attributes:
       pod-overrides:
         spec:

--- a/libs/docs/src/docs/2.2.1-alpha/packaging-devfile.md
+++ b/libs/docs/src/docs/2.2.1-alpha/packaging-devfile.md
@@ -5,7 +5,7 @@ description: Packaging devfile
 
 ## Creating a devfile
 
-To create a devfile, you can [start from scratch](./create-devfiles-with-templates) or use the [public community devfile registry](https://registry.devfile.io/viewer) to find predefined stacks for popular languages and frameworks. Once you have a devfile, save it as `.devfile.yaml` to your application’s root directory.
+To create a devfile, you can [start from scratch](./create-devfiles) or use the [public community devfile registry](https://registry.devfile.io/viewer) to find predefined stacks for popular languages and frameworks. Once you have a devfile, save it as `.devfile.yaml` to your application’s root directory.
 
 ## Resources to include with your devfile
 

--- a/libs/docs/src/docs/no-version/benefits-of-devfile.md
+++ b/libs/docs/src/docs/no-version/benefits-of-devfile.md
@@ -3,6 +3,8 @@ title: Benefits of devfile
 description: Benefits of devfile
 ---
 
+## Why devfiles?
+
 With devfiles, you can make workspaces composed of multiple containers.
 In these containers, you can create any number of identical workspaces
 from the same devfile. If you create multiple workspaces, you can share
@@ -27,6 +29,13 @@ Devfiles have the following benefits:
 - Find available devfile stacks or samples in a devfile registry
 
 - Produce consistent build and run behaviors
+
+## Who is devfile for?
+
+- [Application developers](./application-developer)
+- [Enterprise architects and runtime providers](./enterprise-architect-and-runtime-provider)
+- [Registry administrators](./registry-administrator)
+- [Technology and tool builders](./technology-and-tool-builders)
 
 ## Additional resources
 

--- a/libs/docs/src/docs/no-version/developing-with-devfiles.md
+++ b/libs/docs/src/docs/no-version/developing-with-devfiles.md
@@ -3,6 +3,11 @@ title: Developing with devfiles
 description: Developing with devfiles
 ---
 
+A devfile is a `yaml` file. After you include it in your local
+environment, the devfile provides ways to automate your processes. Tools
+like `odo` run the devfile and apply its guidelines to your environment.
+You can configure the devfile based on your unique development needs.
+
 To get a better understanding of what devfiles can help build, take a look at a few tools that currently support devfile.
 
 ## Quick start guides

--- a/libs/docs/src/navigation/2.2.0.yaml
+++ b/libs/docs/src/navigation/2.2.0.yaml
@@ -12,7 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- title: Components
+- title: General
+  links:
+    - title: Innerloop versus outerloop
+      href: ./innerloop-vs-outerloop
+    - title: Referring to a parent devfile
+      href: ./referring-to-a-parent-devfile
+    - title: Extending kubernetes resources
+      href: ./overriding-pod-and-container-attributes
+- title: API reference
+  links:
+    - title: Devfile schema
+      href: ./devfile-schema
+- title: Authoring devfiles
+  links:
+    - title: Overview
+      href: ./authoring-overview
+    - title: Creating a devfile
+      href: ./create-devfiles
+    - title: Defining variables
+      href: ./defining-variables
+    - title: Defining attributes
+      href: ./defining-attributes
+    - title: Packaging devfile
+      href: ./packaging-devfile
+- title: Authoring devfiles - Projects
+  links:
+    - title: Adding projects
+      href: ./adding-projects
+    - title: Defining starter projects
+      href: ./defining-starter-projects
+- title: Authoring devfiles - Components
   links:
     - title: Adding components
       href: ./adding-components
@@ -32,7 +62,7 @@
       href: ./defining-endpoints
     - title: Defining kubernetes resources
       href: ./defining-kubernetes-resources
-- title: Commands
+- title: Authoring devfiles - Commands
   links:
     - title: Adding commands
       href: ./adding-commands
@@ -44,31 +74,7 @@
       href: ./adding-an-apply-command
     - title: Adding a composite command
       href: ./adding-a-composite-command
-- title: Events
+- title: Authoring devfiles - Events
   links:
     - title: Adding event bindings
       href: ./adding-event-bindings
-- title: General
-  links:
-    - title: Defining variables
-      href: ./defining-variables
-    - title: Defining attributes
-      href: ./defining-attributes
-    - title: Extending kubernetes resources
-      href: ./overriding-pod-and-container-attributes
-    - title: Adding projects
-      href: ./adding-projects
-    - title: Defining starter projects
-      href: ./defining-starter-projects
-    - title: Referring to a parent devfile
-      href: ./referring-to-a-parent-devfile
-    - title: Creating devfiles with templates
-      href: ./create-devfiles-with-templates
-    - title: Innerloop versus outerloop
-      href: ./innerloop-vs-outerloop
-    - title: Packaging devfile
-      href: ./packaging-devfile
-- title: API reference
-  links:
-    - title: Devfile schema
-      href: ./devfile-schema

--- a/libs/docs/src/navigation/2.2.1-alpha.yaml
+++ b/libs/docs/src/navigation/2.2.1-alpha.yaml
@@ -12,7 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- title: Components
+- title: General
+  links:
+    - title: Innerloop versus outerloop
+      href: ./innerloop-vs-outerloop
+    - title: Referring to a parent devfile
+      href: ./referring-to-a-parent-devfile
+    - title: Extending kubernetes resources
+      href: ./overriding-pod-and-container-attributes
+- title: API reference
+  links:
+    - title: Devfile schema
+      href: ./devfile-schema
+- title: Authoring devfiles
+  links:
+    - title: Overview
+      href: ./authoring-overview
+    - title: Creating a devfile
+      href: ./create-devfiles
+    - title: Defining variables
+      href: ./defining-variables
+    - title: Defining attributes
+      href: ./defining-attributes
+    - title: Packaging devfile
+      href: ./packaging-devfile
+- title: Authoring devfiles - Projects
+  links:
+    - title: Adding projects
+      href: ./adding-projects
+    - title: Defining starter projects
+      href: ./defining-starter-projects
+- title: Authoring devfiles - Components
   links:
     - title: Adding components
       href: ./adding-components
@@ -32,7 +62,7 @@
       href: ./defining-endpoints
     - title: Defining kubernetes resources
       href: ./defining-kubernetes-resources
-- title: Commands
+- title: Authoring devfiles - Commands
   links:
     - title: Adding commands
       href: ./adding-commands
@@ -44,31 +74,7 @@
       href: ./adding-an-apply-command
     - title: Adding a composite command
       href: ./adding-a-composite-command
-- title: Events
+- title: Authoring devfiles - Events
   links:
     - title: Adding event bindings
       href: ./adding-event-bindings
-- title: General
-  links:
-    - title: Defining variables
-      href: ./defining-variables
-    - title: Defining attributes
-      href: ./defining-attributes
-    - title: Extending kubernetes resources
-      href: ./overriding-pod-and-container-attributes
-    - title: Adding projects
-      href: ./adding-projects
-    - title: Defining starter projects
-      href: ./defining-starter-projects
-    - title: Referring to a parent devfile
-      href: ./referring-to-a-parent-devfile
-    - title: Creating devfiles with templates
-      href: ./create-devfiles-with-templates
-    - title: Innerloop versus outerloop
-      href: ./innerloop-vs-outerloop
-    - title: Packaging devfile
-      href: ./packaging-devfile
-- title: API reference
-  links:
-    - title: Devfile schema
-      href: ./devfile-schema

--- a/libs/docs/src/navigation/no-version.yaml
+++ b/libs/docs/src/navigation/no-version.yaml
@@ -19,38 +19,16 @@ top:
         href: ./what-is-a-devfile
       - title: Benefits of devfile
         href: ./benefits-of-devfile
-      - title: Users of devfile
-        href: ./users-of-devfile
-      - title: How to work with devfiles
-        href: ./how-to-work-with-devfiles
-      - title: Developing with devfiles
-        href: ./developing-with-devfiles
-  - title: Quick start
-    links:
-      - title: Overview
-        href: ./overview
-      - title: Versions
-        href: ./versions
-      - title: Metadata
-        href: ./metadata
-      - title: Library
-        href: ./library
-      - title: Resources
-        href: ./resources
-      - title: Integrate with editors
-        href: ./integrate-with-editors
-  - title: Get started
-    links:
       - title: Devfile ecosystem
         href: ./devfile-ecosystem
-      - title: Application developer
-        href: ./application-developer
-      - title: Enterprise architect and runtime provider
-        href: ./enterprise-architect-and-runtime-provider
-      - title: Registry administrator
-        href: ./registry-administrator
-      - title: Technology and tool builders
-        href: ./technology-and-tool-builders
+  - title: Get started
+    links:
+      - title: Developing with devfiles
+        href: ./developing-with-devfiles
+      - title: Integrate with editors
+        href: ./integrate-with-editors
+      - title: Library
+        href: ./library
 bottom:
   - title: Registry
     links:


### PR DESCRIPTION
## What does this PR do / why we need it

Reorganized the sidebar navigation for 2.2.0 and 2.2.1-alpha with a focus on
* Reducing the amount of general introduction topics; ~~all persona docs removed – can add to landing page instead~~
* Giving more visibility to creating and writing devfiles
* Highlighting that Projects, Components, Commands, and Events are related to Authoring devfiles

## Which issue(s) does this PR fix

Fixes https://github.com/devfile/api/issues/1079

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [x] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

## How to test changes / Special notes to the reviewer
