### PR TITLE
Document behavior of the devfile library when parsing directory with multiple filename variants of a devfile

### DIFF
--- a/libs/docs/src/docs/no-version/library.md
+++ b/libs/docs/src/docs/no-version/library.md
@@ -9,7 +9,10 @@ for teams to collaborate across shared projects.
 
 ## Procedure
 
-- Parse a devfile by running:
+- Parse a devfile with the code below.
+  Note that the `Path` field in the `parser.ParserArgs` struct can be a relative or absolute path to any file or directory on the filesystem.
+  If it is a directory containing several files, the parser will try to discover a devfile based on the following file name priority order:
+  `devfile.yaml` > `.devfile.yaml` > `devfile.yml` > `.devfile.yml`.
 
 ```go
 // ParserArgs is the struct to pass into parser functions


### PR DESCRIPTION
## What does this PR do / why we need it

This is a follow-up PR to https://github.com/devfile/library/pull/186.
It makes sure to document the behavior of the library when the parser is provided a directory path containing multiple filename variants of a devfile, in particular the priority order in which a devfile is determined and picked.

## Which issue(s) does this PR fix

Fixes https://github.com/devfile/api/issues/1265

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [x] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

## How to test changes / Special notes to the reviewer
