### PR TITLE
add podman script/alias support to build and push scripts

### DIFF
--- a/scripts/build_viewer.sh
+++ b/scripts/build_viewer.sh
@@ -13,9 +13,14 @@
 # limitations under the License.
 
 #!/usr/bin/env bash
+shopt -s expand_aliases
+set -eux
 
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR=$ABSOLUTE_PATH/..
+
+# Set Docker/Podman alias if necessary
+. ${ABSOLUTE_PATH}/setenv.sh
 
 docker build --no-cache -t registry-viewer $BUILD_DIR \
     --build-arg PROJECT_NAME=registry-viewer \

--- a/scripts/setenv.sh
+++ b/scripts/setenv.sh
@@ -1,10 +1,13 @@
+#!/bin/bash
+
+#
 # Copyright Red Hat
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,17 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env bash
-shopt -s expand_aliases
-set -eux
+# This script aliases the docker cli if the environment variable USE_PODMAN is set to true.
 
-BASE_TAG=$1
-IMAGE_TAG=$2
-
-ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# Set Docker/Podman alias if necessary
-. ${ABSOLUTE_PATH}/setenv.sh
-
-docker tag $BASE_TAG $IMAGE_TAG
-docker push $IMAGE_TAG
+# default value is false if USE_PODMAN is unset or null
+podman=${USE_PODMAN:-false}
+if [ ${podman} == true ]; then
+  alias docker=podman
+  echo "setting alias docker=podman"
+fi


### PR DESCRIPTION
## What does this PR do / why we need it

Adds the necessary env script to the repository to enable the use of Podman or Docker as the container engine for the build and push scripts.

## Which issue(s) does this PR fix
Fixes #?
resolves https://github.com/devfile/api/issues/1355
## PR acceptance criteria

- [ ] Builds the images using Docker with USE_PODMAN=false and using Podman with USE_PODMAN=true

## How to test changes / Special notes to the reviewer
Run the build and push scripts with the env set and unset to test the image building