### PR TITLE
Update dockerfile for parcel/watcher package fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,7 @@ Owners of the repository will watch out for and review new PRs.
 If comments have been given in a review, they have to be addressed before merging.
 
 After addressing review comments, don’t forget to add a comment in the PR afterward, so everyone gets notified by Github and knows to re-review.
+
+## Troubleshooting
+
+- There is a known issue with Apple Silicon (arm64) architectures that may cause the `build_viewer.sh` script to fail. If this issue occurs first run `export PLATFORM_EV=linux/arm64`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ USER root
 # Install yarn & node-gyp dependency
 RUN \
   curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
-  microdnf install -y yarn python3 gcc-c++ && \
+  microdnf install -y yarn python3 gcc-c++ make && \
   npm install --build-from-resource node-gyp
 
 # Project non-specific args

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,11 @@
 FROM registry.access.redhat.com/ubi9/nodejs-18-minimal AS deps
 USER root
 
-# Install yarn
+# Install yarn & node-gyp dependency
 RUN \
   curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
-  microdnf install -y yarn
+  microdnf install -y yarn python3 gcc-c++ && \
+  npm install --build-from-resource node-gyp
 
 # Project non-specific args
 ARG PROJECT_NAME

--- a/package.json
+++ b/package.json
@@ -121,13 +121,5 @@
     "typescript": "^4.9.3",
     "url-loader": "^4.1.1",
     "webpack": "^5.76.0"
-  },
-  "overrides": {
-    "@nrwl/workspace": {
-      "@parcel/watcher": "2.1.0"
-    },
-    "@nx": {
-      "@parcel/watcher": "2.1.0"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -121,5 +121,13 @@
     "typescript": "^4.9.3",
     "url-loader": "^4.1.1",
     "webpack": "^5.76.0"
+  },
+  "overrides": {
+    "@nrwl/workspace": {
+      "@parcel/watcher": "2.3.0"
+    },
+    "@nx": {
+      "@parcel/watcher": "2.3.0"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -124,10 +124,10 @@
   },
   "overrides": {
     "@nrwl/workspace": {
-      "@parcel/watcher": "2.3.0"
+      "@parcel/watcher": "2.1.0"
     },
     "@nx": {
-      "@parcel/watcher": "2.3.0"
+      "@parcel/watcher": "2.1.0"
     }
   }
 }

--- a/scripts/build_viewer.sh
+++ b/scripts/build_viewer.sh
@@ -18,10 +18,11 @@ set -eux
 
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR=$ABSOLUTE_PATH/..
+PLATFORM_EV=${PLATFORM_EV:-"linux/amd64"}
 
 # Set Docker/Podman alias if necessary
 . ${ABSOLUTE_PATH}/setenv.sh
 
-docker build --no-cache -t registry-viewer $BUILD_DIR \
+docker build --platform ${PLATFORM_EV} --no-cache -t registry-viewer $BUILD_DIR \
     --build-arg PROJECT_NAME=registry-viewer \
     --build-arg NEXT_PUBLIC_BASE_PATH=${NEXT_PUBLIC_BASE_PATH:-"/viewer"}


### PR DESCRIPTION
## What does this PR do / why we need it

This PR tries to fix the issue with `@parcel/watcher` package and the `node-gyp` dependency. The issue comes from the `2.0.4` of the `watcher` package. This is a known issue which has been fixed here https://github.com/nrwl/nx/pull/19751. As a result in order to have a full fix of this issue we might need to update to `nx 17.1.3`.

As the update of `nx` dep might require a fair amount of changes to the `package.json` of the project, as a temporary solution we can add overrides to the `package.json` in order to use the version `2.1.0`.

Another required step is to install `gcc`, `make` and `python3` deps.

More info about the fixes can be found here: https://github.com/parcel-bundler/watcher/issues/156#issuecomment-1721077490 & here: https://github.com/nrwl/nx/issues/19457

Other than that, the fix also introduces an ENV var in order to allow users to run the `build_viewer.sh` script with for specific architectures. This way people running on silicon can choose a different arch.

## Which issue(s) does this PR fix

Fixes https://github.com/devfile/api/issues/1356

## PR acceptance criteria

- [x] Unit Tests
- [x] E2E Tests
- [x] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

## How to test changes / Special notes to the reviewer

In order to reproduce it to a non-silicon environment I've tried to run:

```
ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
BUILD_DIR=$ABSOLUTE_PATH/..

docker buildx build --platform linux/arm64 --no-cache -t registry-viewer $BUILD_DIR \
    --build-arg PROJECT_NAME=registry-viewer \
    --build-arg NEXT_PUBLIC_BASE_PATH=${NEXT_PUBLIC_BASE_PATH:-"/viewer"}
```