### PR TITLE
[DO NOT MERGE] TEMP update docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   main:
     name: Main Job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04.3
 
     env:
       NX_SKIP_NX_CACHE: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   main:
     name: Main Job
-    runs-on: ubuntu-22.04.3
+    runs-on: ubuntu-20.04
 
     env:
       NX_SKIP_NX_CACHE: true

--- a/libs/docs/src/docs/2.1.0/defining-endpoints.md
+++ b/libs/docs/src/docs/2.1.0/defining-endpoints.md
@@ -5,6 +5,8 @@ description: Defining endpoints
 
 Components of any type can specify the endpoints that the container exposes. These endpoints can be made accessible to the users if the {prod-short} cluster is running using a Kubernetes ingress or an OpenShift route and to the other components within the workspace. You can create an endpoint for your application or database, if your application or database server is listening on a port and you want to be able to directly interact with it yourself or you want other components to interact with it.
 
+TEMP UPDATE - DOC
+
 ## Procedure
 
 1. Specify endpoints properties as shown in the following example:


### PR DESCRIPTION
## What does this PR do / why we need it

Temp PR in order to test the E2E workflow failure:
* Reproduce the failure.
* Try to pin the ubuntu version of the `.github/workflows/ci.yaml` to `20.04` instead of `22.04.4` (`ubuntu-latest`)

## Which issue(s) does this PR fix

Fixes #?

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

## How to test changes / Special notes to the reviewer
