### PR TITLE
Add deprecated stack filter on the registry-viewer and fix deprecated Color

### DIFF
--- a/apps/registry-viewer/pages/index.tsx
+++ b/apps/registry-viewer/pages/index.tsx
@@ -141,7 +141,10 @@ function sortFilterElements(filterElements: FilterElement[]): FilterElement[] {
 
 function getFilterElements(
   devfiles: Devfile[],
-  property: keyof Pick<Devfile, 'tags' | 'type' | 'provider' | 'language' | '_registry' | '_deprecated' >,
+  property: keyof Pick<
+    Devfile,
+    'tags' | 'type' | 'provider' | 'language' | '_registry' | '_deprecated'
+  >,
   queryParam: string[],
 ): FilterElement[] {
   let elements: string[] = [];

--- a/apps/registry-viewer/pages/index.tsx
+++ b/apps/registry-viewer/pages/index.tsx
@@ -142,8 +142,8 @@ function sortFilterElements(filterElements: FilterElement[]): FilterElement[] {
 function getFilterElements(
   devfiles: Devfile[],
   property: keyof Pick<
-    Devfile,
-    'tags' | 'type' | 'provider' | 'language' | '_registry' | '_deprecated'
+  Devfile,
+  'tags' | 'type' | 'provider' | 'language' | '_registry' | '_deprecated'
   >,
   queryParam: string[],
 ): FilterElement[] {

--- a/apps/registry-viewer/pages/index.tsx
+++ b/apps/registry-viewer/pages/index.tsx
@@ -141,7 +141,7 @@ function sortFilterElements(filterElements: FilterElement[]): FilterElement[] {
 
 function getFilterElements(
   devfiles: Devfile[],
-  property: keyof Pick<Devfile, 'tags' | 'type' | 'provider' | 'language' | '_registry'>,
+  property: keyof Pick<Devfile, 'tags' | 'type' | 'provider' | 'language' | '_registry' | '_deprecated' >,
   queryParam: string[],
 ): FilterElement[] {
   let elements: string[] = [];
@@ -152,9 +152,10 @@ function getFilterElements(
       if (Array.isArray(value)) {
         prev.push(...value);
       } else if (typeof value === 'string') {
+        // _deprecated
         prev.push(value);
       } else {
-        // _registry
+        // _registry,
         prev.push(value.name);
       }
     }
@@ -194,6 +195,7 @@ export const getServerSideProps: GetServerSideProps<IndexProps> = async (context
   const typeParam = getArrayParam(context.query.types);
   const providerParam = getArrayParam(context.query.providers);
   const languageParam = getArrayParam(context.query.languages);
+  const deprecatedParam = getArrayParam(context.query.deprecated);
 
   // get the devfiles
   const devfileRegistries = getDevfileRegistries();
@@ -213,11 +215,13 @@ export const getServerSideProps: GetServerSideProps<IndexProps> = async (context
       isSearchIn(devfile.tags, tagParam) &&
       isSearchIn(devfile.type, typeParam) &&
       isSearchIn(devfile.provider, providerParam) &&
-      isSearchIn(devfile.language, languageParam),
+      isSearchIn(devfile.language, languageParam) &&
+      isSearchIn(devfile._deprecated, deprecatedParam),
   );
 
   // get the filter elements
   const registries = getFilterElements(devfiles, '_registry', registryParam);
+  const deprecated = getFilterElements(devfiles, '_deprecated', deprecatedParam);
   const tags = getFilterElements(devfiles, 'tags', tagParam);
   const types = getFilterElements(devfiles, 'type', typeParam);
   const providers = getFilterElements(devfiles, 'provider', providerParam);
@@ -242,6 +246,7 @@ export const getServerSideProps: GetServerSideProps<IndexProps> = async (context
         types,
         providers,
         languages,
+        deprecated,
       },
     },
   };

--- a/apps/registry-viewer/pages/index.tsx
+++ b/apps/registry-viewer/pages/index.tsx
@@ -139,12 +139,11 @@ function sortFilterElements(filterElements: FilterElement[]): FilterElement[] {
   });
 }
 
+let fitlerProperties: 'tags' | 'type' | 'provider' | 'language' | '_registry' | '_deprecated';
+
 function getFilterElements(
   devfiles: Devfile[],
-  property: keyof Pick<
-    Devfile,
-    'tags' | 'type' | 'provider' | 'language' | '_registry' | '_deprecated'
-  >,
+  property: keyof Pick<Devfile, typeof fitlerProperties>,
   queryParam: string[],
 ): FilterElement[] {
   let elements: string[] = [];

--- a/apps/registry-viewer/pages/index.tsx
+++ b/apps/registry-viewer/pages/index.tsx
@@ -155,7 +155,7 @@ function getFilterElements(
         // _deprecated
         prev.push(value);
       } else {
-        // _registry,
+        // _registry
         prev.push(value.name);
       }
     }

--- a/apps/registry-viewer/pages/index.tsx
+++ b/apps/registry-viewer/pages/index.tsx
@@ -142,8 +142,8 @@ function sortFilterElements(filterElements: FilterElement[]): FilterElement[] {
 function getFilterElements(
   devfiles: Devfile[],
   property: keyof Pick<
-  Devfile,
-  'tags' | 'type' | 'provider' | 'language' | '_registry' | '_deprecated'
+    Devfile,
+    'tags' | 'type' | 'provider' | 'language' | '_registry' | '_deprecated'
   >,
   queryParam: string[],
 ): FilterElement[] {

--- a/libs/core/src/components/devfile-datalist/devfile-datalist.tsx
+++ b/libs/core/src/components/devfile-datalist/devfile-datalist.tsx
@@ -23,7 +23,7 @@ import { compareSemanticVersions, type Devfile } from '../../functions';
 import type { DevfileSpec } from '../../types';
 import {
   getDevfileTags,
-  getDevfileTagClasses,
+  isDeprecatedDevfile,
 } from '../../functions/get-devfile-tags/get-devfile-tags';
 
 export interface DevfileDatalistProps {
@@ -131,9 +131,21 @@ export function DevfileDatalist(props: DevfileDatalistProps): JSX.Element {
               <ul className="flex flex-wrap gap-2">
                 {devfileTags.map((tag) => (
                   <li key={tag}>
-                    <Link href={`/?tags=${tag}`} className={getDevfileTagClasses(tag)}>
-                      {tag}
-                    </Link>
+                    {isDeprecatedDevfile(tag) ? (
+                      <Link
+                        href={`/?tags=${tag}`}
+                        className="bg-deprecated/5 hover:bg-deprecated/10 active:bg-deprecated/20 border-deprecated/50 text-deprecated inline-flex items-center rounded border px-2.5 py-0.5 text-xs font-medium"
+                      >
+                        {tag}
+                      </Link>
+                    ) : (
+                      <Link
+                        href={`/?tags=${tag}`}
+                        className="bg-devfile/5 hover:bg-devfile/10 active:bg-devfile/20 border-devfile/50 text-devfile inline-flex items-center rounded border px-2.5 py-0.5 text-xs font-medium"
+                      >
+                        {tag}
+                      </Link>
+                    )}
                   </li>
                 ))}
               </ul>

--- a/libs/core/src/components/devfile-filters/devfile-filters.tsx
+++ b/libs/core/src/components/devfile-filters/devfile-filters.tsx
@@ -29,7 +29,7 @@ export interface FilterParams {
   types: FilterElement[];
   providers: FilterElement[];
   languages: FilterElement[];
-  deprecated: FilterParams[];
+  deprecated: FilterElement[];
 }
 
 const filters: {

--- a/libs/core/src/components/devfile-filters/devfile-filters.tsx
+++ b/libs/core/src/components/devfile-filters/devfile-filters.tsx
@@ -29,6 +29,7 @@ export interface FilterParams {
   types: FilterElement[];
   providers: FilterElement[];
   languages: FilterElement[];
+  deprecated: FilterParams[];
 }
 
 const filters: {
@@ -37,6 +38,7 @@ const filters: {
   capitalize: boolean;
 }[] = [
   { name: 'Registries', property: 'registries', capitalize: false },
+  { name: 'Deprecated', property: 'deprecated', capitalize: false },
   { name: 'Tags', property: 'tags', capitalize: false },
   { name: 'Types', property: 'types', capitalize: true },
   { name: 'Providers', property: 'providers', capitalize: false },

--- a/libs/core/src/components/devfile-grid/devfile-grid.tsx
+++ b/libs/core/src/components/devfile-grid/devfile-grid.tsx
@@ -19,7 +19,7 @@ import Link from 'next/link';
 import slugify from '@sindresorhus/slugify';
 import { Devfile } from '../../functions';
 
-import { getDevfileTagClasses } from '../../functions/get-devfile-tags/get-devfile-tags';
+import { isDeprecatedDevfile } from '../../functions/get-devfile-tags/get-devfile-tags';
 
 export interface DevfileGridProps {
   devfiles: Devfile[];
@@ -75,11 +75,23 @@ export function DevfileGrid(props: DevfileGridProps): JSX.Element {
               </div>
               {devfile.tags && (
                 <div className="mt-2 flex flex-wrap gap-2 md:mt-4">
-                  {devfile.tags.slice(0, 4).map((tag) => (
-                    <span key={tag} className={getDevfileTagClasses(tag)}>
-                      {tag}
-                    </span>
-                  ))}
+                  {devfile.tags.slice(0, 4).map((tag) =>
+                    isDeprecatedDevfile(tag) ? (
+                      <span
+                        key={tag}
+                        className="bg-deprecated/5 hover:bg-deprecated/10 active:bg-deprecated/20 border-deprecated/50 text-deprecated inline-flex items-center rounded border px-2.5 py-0.5 text-xs font-medium"
+                      >
+                        {tag}
+                      </span>
+                    ) : (
+                      <span
+                        key={tag}
+                        className="bg-devfile/5 hover:bg-devfile/10 active:bg-devfile/20 border-devfile/50 text-devfile inline-flex items-center rounded border px-2.5 py-0.5 text-xs font-medium"
+                      >
+                        {tag}
+                      </span>
+                    ),
+                  )}
                 </div>
               )}
             </Link>

--- a/libs/core/src/functions/fetch-devfiles/fetch-devfiles.spec.tsx
+++ b/libs/core/src/functions/fetch-devfiles/fetch-devfiles.spec.tsx
@@ -45,6 +45,7 @@ describe('fetchDevfiles', () => {
       .map((devfile) => ({
         ...devfile,
         _registry: devfileRegistries[0],
+        _deprecated: 'No',
       }))
       .sort((a, b) =>
         a.displayName.localeCompare(b.displayName, 'en', {

--- a/libs/core/src/functions/fetch-devfiles/fetch-devfiles.tsx
+++ b/libs/core/src/functions/fetch-devfiles/fetch-devfiles.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { getDeprecatedDevfileValue } from '../get-deprecated-devfile-value/get-devfile-tags';
+
 interface DevfileJsonBase {
   name: string;
   displayName: string;
@@ -68,6 +70,7 @@ export interface Registry {
 
 export type Devfile = DevfileJson & {
   _registry: Registry;
+  _deprecated: string;
 };
 
 export interface DevfileParams {
@@ -95,6 +98,7 @@ export async function fetchDevfiles(registries: Registry[]): Promise<Devfile[]> 
       devfileJsons[devfileRegistryIndex].map((devfile) => ({
         ...devfile,
         _registry: registry,
+        _deprecated: getDeprecatedDevfileValue(devfile),
       })),
     )
     .sort((a, b) =>

--- a/libs/core/src/functions/fetch-devfiles/fetch-devfiles.tsx
+++ b/libs/core/src/functions/fetch-devfiles/fetch-devfiles.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getDeprecatedDevfileValue } from '../get-deprecated-devfile-value/get-devfile-tags';
+import { getDeprecatedDevfileValue } from '../get-deprecated-devfile-value/get-deprecated-devfile-value';
 
 interface DevfileJsonBase {
   name: string;

--- a/libs/core/src/functions/get-deprecated-devfile-value/get-deprecated-devfile-value.spec.tsx
+++ b/libs/core/src/functions/get-deprecated-devfile-value/get-deprecated-devfile-value.spec.tsx
@@ -16,8 +16,11 @@
 
 import { DevfileJson } from '../fetch-devfiles/fetch-devfiles';
 import { DeprecatedTag } from '../get-devfile-tags/get-devfile-tags';
-import { IsNotDeprecatedValue, IsDeprecatedValue, getDeprecatedDevfileValue } from './get-deprecated-devfile-value';
-
+import {
+  IsNotDeprecatedValue,
+  IsDeprecatedValue,
+  getDeprecatedDevfileValue,
+} from './get-deprecated-devfile-value';
 
 let deprecatedDevfileJson: DevfileJson;
 

--- a/libs/core/src/functions/get-deprecated-devfile-value/get-deprecated-devfile-value.spec.tsx
+++ b/libs/core/src/functions/get-deprecated-devfile-value/get-deprecated-devfile-value.spec.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DevfileJson } from '../fetch-devfiles/fetch-devfiles';
+import { DeprecatedTag } from '../get-devfile-tags/get-devfile-tags';
+import { IsNotDeprecatedValue, IsDeprecatedValue, getDeprecatedDevfileValue } from './get-deprecated-devfile-value';
+
+
+let deprecatedDevfileJson: DevfileJson;
+
+let nonDeprecatedDevfileJson: DevfileJson;
+
+describe('getDeprecatedDevfileValue', () => {
+  it('should execute successfully', () => {
+    deprecatedDevfileJson = {
+      name: 'some devfile',
+      displayName: 'display name',
+      description: 'some description',
+      type: 'stack',
+      tags: ['three', 'four', DeprecatedTag],
+      icon: '',
+      projectType: 'python',
+      language: 'python',
+      versions: [],
+      provider: 'provider',
+      architectures: [],
+      git: {
+        remotes: {},
+      },
+    };
+    nonDeprecatedDevfileJson = {
+      name: 'some devfile',
+      displayName: 'display name',
+      description: 'some description',
+      type: 'stack',
+      tags: ['three', 'four'],
+      icon: '',
+      projectType: 'python',
+      language: 'python',
+      versions: [],
+      provider: 'provider',
+      architectures: [],
+      git: {
+        remotes: {},
+      },
+    };
+    expect(getDeprecatedDevfileValue(deprecatedDevfileJson)).toEqual(IsDeprecatedValue);
+    expect(getDeprecatedDevfileValue(nonDeprecatedDevfileJson)).toEqual(IsNotDeprecatedValue);
+  });
+});

--- a/libs/core/src/functions/get-deprecated-devfile-value/get-deprecated-devfile-value.tsx
+++ b/libs/core/src/functions/get-deprecated-devfile-value/get-deprecated-devfile-value.tsx
@@ -26,9 +26,7 @@ export const IsNotDeprecatedValue = 'No';
  *
  * @returns 'Yes' or 'No'
  */
-export function getDeprecatedDevfileValue(
-  devfile: DevfileJson,
-): string {
+export function getDeprecatedDevfileValue(devfile: DevfileJson): string {
   if (devfile.tags.includes(DeprecatedTag)) {
     return IsDeprecatedValue;
   }

--- a/libs/core/src/functions/get-deprecated-devfile-value/get-deprecated-devfile-value.tsx
+++ b/libs/core/src/functions/get-deprecated-devfile-value/get-deprecated-devfile-value.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DevfileJson } from '../fetch-devfiles/fetch-devfiles';
+import { DeprecatedTag } from '../get-devfile-tags/get-devfile-tags';
+
+export const IsDeprecatedValue = 'Yes';
+
+export const IsNotDeprecatedValue = 'No';
+
+/**
+ * Checks if a devfile tags include the DeprecatedTag
+ *
+ * @returns 'Yes' or 'No'
+ */
+export function getDeprecatedDevfileValue(
+  devfile: DevfileJson,
+): string {
+  if (devfile.tags.includes(DeprecatedTag)) {
+    return IsDeprecatedValue;
+  }
+  return IsNotDeprecatedValue;
+}

--- a/libs/core/src/functions/get-devfile-tags/get-devfile-tags.spec.tsx
+++ b/libs/core/src/functions/get-devfile-tags/get-devfile-tags.spec.tsx
@@ -15,7 +15,7 @@
  */
 
 import { VersionDevfile, Devfile, Registry } from '../fetch-devfiles/fetch-devfiles';
-import { DeprecatedTag, getDevfileTags, getDevfileTagClasses } from './get-devfile-tags';
+import { DeprecatedTag, getDevfileTags, isDeprecatedDevfile } from './get-devfile-tags';
 
 let undefinedVersionDevfile: undefined;
 
@@ -66,11 +66,7 @@ describe('getDevfileTags', () => {
 
 describe('getDevfileTags', () => {
   it('should execute successfully', () => {
-    const devfileClassName =
-      'bg-devfile/5 hover:bg-devfile/10 active:bg-devfile/20 border-devfile/50 text-devfile inline-flex items-center rounded border px-2.5 py-0.5 text-xs font-medium';
-    const deprecatedClassName =
-      'bg-deprecated/5 hover:bg-deprecated/10 active:bg-deprecated/20 border-deprecated/50 text-deprecated inline-flex items-center rounded border px-2.5 py-0.5 text-xs font-medium';
-    expect(getDevfileTagClasses(DeprecatedTag)).toEqual(deprecatedClassName);
-    expect(getDevfileTagClasses('tag')).toEqual(devfileClassName);
+    expect(isDeprecatedDevfile(DeprecatedTag)).toEqual(true);
+    expect(isDeprecatedDevfile('tag')).toEqual(false);
   });
 });

--- a/libs/core/src/functions/get-devfile-tags/get-devfile-tags.spec.tsx
+++ b/libs/core/src/functions/get-devfile-tags/get-devfile-tags.spec.tsx
@@ -15,7 +15,7 @@
  */
 
 import { VersionDevfile, Devfile, Registry } from '../fetch-devfiles/fetch-devfiles';
-import { deprecatedTag, getDevfileTags, getDevfileTagClasses } from './get-devfile-tags';
+import { DeprecatedTag, getDevfileTags, getDevfileTagClasses } from './get-devfile-tags';
 
 let undefinedVersionDevfile: undefined;
 
@@ -43,6 +43,7 @@ describe('getDevfileTags', () => {
     };
     devfile = {
       _registry: registry,
+      _deprecated: 'False',
       name: 'some devfile',
       displayName: 'display name',
       description: 'some description',
@@ -69,7 +70,7 @@ describe('getDevfileTags', () => {
       'bg-devfile/5 hover:bg-devfile/10 active:bg-devfile/20 border-devfile/50 text-devfile inline-flex items-center rounded border px-2.5 py-0.5 text-xs font-medium';
     const deprecatedClassName =
       'bg-deprecated/5 hover:bg-deprecated/10 active:bg-deprecated/20 border-deprecated/50 text-deprecated inline-flex items-center rounded border px-2.5 py-0.5 text-xs font-medium';
-    expect(getDevfileTagClasses(deprecatedTag)).toEqual(deprecatedClassName);
+    expect(getDevfileTagClasses(DeprecatedTag)).toEqual(deprecatedClassName);
     expect(getDevfileTagClasses('tag')).toEqual(devfileClassName);
   });
 });

--- a/libs/core/src/functions/get-devfile-tags/get-devfile-tags.tsx
+++ b/libs/core/src/functions/get-devfile-tags/get-devfile-tags.tsx
@@ -16,7 +16,7 @@
 
 import { Devfile, VersionDevfile } from '../fetch-devfiles/fetch-devfiles';
 
-export const deprecatedTag = 'Deprecated';
+export const DeprecatedTag = 'Deprecated';
 /**
  * Checks if a versionDevfile exists and returns its tags. If
  * it doesn't exists returns the devfile tags
@@ -40,8 +40,8 @@ export function getDevfileTags(
  */
 export function getDevfileTagClasses(tag: string): string {
   let colorTag = 'devfile';
-  if (tag === deprecatedTag) {
-    colorTag = deprecatedTag.toLowerCase();
+  if (tag === DeprecatedTag) {
+    colorTag = DeprecatedTag.toLowerCase();
   }
   return `bg-${colorTag}/5 hover:bg-${colorTag}/10 active:bg-${colorTag}/20 border-${colorTag}/50 text-${colorTag} inline-flex items-center rounded border px-2.5 py-0.5 text-xs font-medium`;
 }

--- a/libs/core/src/functions/get-devfile-tags/get-devfile-tags.tsx
+++ b/libs/core/src/functions/get-devfile-tags/get-devfile-tags.tsx
@@ -34,16 +34,15 @@ export function getDevfileTags(
 }
 
 /**
- * Checks if the given tag is equal to depracatedTag and returns the necessary css classes
+ * Checks if the given tag is equal to depracatedTag
  *
- * @returns the class names according to the given tag
+ * @returns bolean value
  */
-export function getDevfileTagClasses(tag: string): string {
-  let colorTag = 'devfile';
+export function isDeprecatedDevfile(tag: string): boolean {
   if (tag === DeprecatedTag) {
-    colorTag = DeprecatedTag.toLowerCase();
+    return true;
   }
-  return `bg-${colorTag}/5 hover:bg-${colorTag}/10 active:bg-${colorTag}/20 border-${colorTag}/50 text-${colorTag} inline-flex items-center rounded border px-2.5 py-0.5 text-xs font-medium`;
+  return false;
 }
 
 export default getDevfileTags;


### PR DESCRIPTION
## What does this PR do / why we need it

This PR adds a filter inside the registry viewer so we can filter out deprecated or non deprecated stacks. A deprecated stack is considered when the `Deprecated` tag is added on the default version main tag section.

Note that if all the stacks are deprecated or non-deprecated the filter is not appearing (this is the default configuration for our filters)

Example image:
![image](https://github.com/devfile/devfile-web/assets/12788684/b9b34e51-f7f5-4c7d-9366-375ef85150de)

An additional fix for this PR is the deprecated color. As it can be seen [here](https://registry.devfile.io/viewer/devfiles/community/go?devfile-version=2.1.0) the [deprecated](https://github.com/devfile/devfile-web/blob/main/apps/registry-viewer/tailwind.config.js#L48) color is not visible.

The fix simply hardcodes the 2 cases of tag colors (following all other cases of style classes) so tailwind can load them when we run the project.

## Which issue(s) does this PR fix

Fixes https://github.com/devfile/api/issues/1064

## PR acceptance criteria

- [x] Unit Tests
- [x] E2E Tests
- [x] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

## How to test changes / Special notes to the reviewer

To test the changes someone should:

* Run minikube locally.
* Build a new image of registry with a stack that is deprecated (currently all stacks are not deprecated).
* [Deploy a registry deployment to minikube](https://github.com/devfile/registry-support?tab=readme-ov-file#deploy)
* Run the registry viewer locally with:
```
DEVFILE_REGISTRIES='[{"name":"Community","url":"http://<your registry's address>","fqdn":"/<your registry's address>"}]' yarn nx serve registry-viewer --configuration=development
```