### PR TITLE
Update meetings information on community page

### DIFF
--- a/libs/docs/src/docs/no-version/community.md
+++ b/libs/docs/src/docs/no-version/community.md
@@ -13,9 +13,9 @@ Join the [Devfile Community](https://groups.google.com/g/devfiles-community) gro
 
 ### Meetings
 
-We run regular meetings that are open to anyone who wants to participate. The meetings take place every Monday at 9 AM EST. To join the meetings, please join the [Devfile Community Google Group](https://groups.google.com/g/devfiles-community).
+The meetings are ad-hoc and are arranged at our discretion based on discussions on our [slack channel](#slack). Meetings are open to anyone who wants to participate. To join the meetings, please join the [Devfile Community Google Group](https://groups.google.com/g/devfiles-community).
 
-In addition to joining our regular meetings, we welcome anyone who wants to suggest topics for discussion. If you have a specific topic you’d like to raise, please add it to the agenda for the upcoming meeting. The agenda can be found in the calendar event for each meeting.
+We welcome anyone who wants to suggest topics for discussion. If you have a specific topic you’d like to raise, please add it to the agenda for the upcoming meeting. The agenda can be found in the calendar event for each meeting.
 
 We look forward to hearing your ideas!
 


### PR DESCRIPTION
## What does this PR do / why we need it

Updates the out of date information about meetings on the community page. Meetings are now ad-hoc instead of every Monday at 9AM EST on a regular schedule.

## Which issue(s) does this PR fix

Fixes #?

https://github.com/devfile/api/issues/1515

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [X] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

## How to test changes / Special notes to the reviewer

1. `yarn install`
2. `yarn nx test landing-page`
3. `yarn nx serve landing-page`
