### PR TITLE
Update eclipse.org to eclipse.dev

### DIFF
--- a/libs/docs/src/docs/no-version/developing-with-devfiles.md
+++ b/libs/docs/src/docs/no-version/developing-with-devfiles.md
@@ -19,7 +19,7 @@ automates and simplifies your development process.
     - Get started with [odo](https://odo.dev/docs/user-guides/quickstart/nodejs).
 - Create a workspace in `Eclipse Che` with a community sample backed by the devfile specification to start building your application in the language of your choice.
     - [Quick start with Eclipse Che](./quickstart-che)
-    - Get started with [Eclipse Che](https://www.eclipse.org/che/).
+    - Get started with [Eclipse Che](https://www.eclipse.dev/che/).
 - Use blueprints in `Amazon CodeCatalyst` to quickly build a "Modern three-tier web application". Start working on the source code with a Dev Environment that uses a devfile to pre-determine and install the required project tools and application libraries.
     - Get started with [Amazon CodeCatalyst](https://docs.aws.amazon.com/codecatalyst/latest/userguide/getting-started-template-project.html).
 - Set up a remote development environment that links to your Git repository using `JetBrains Space Cloud Dev` and the devfile specification.

--- a/libs/docs/src/docs/no-version/quickstart-che.md
+++ b/libs/docs/src/docs/no-version/quickstart-che.md
@@ -13,10 +13,10 @@ This guide will run through creating a simple hello world devfile project using 
 
 ## Procedure
 
-1. Obtain access to Eclipse Che if you do not already have it, as an individual this can be done by setting up a [local instance of Eclipse Che](https://www.eclipse.org/che/docs/stable/administration-guide/installing-che-locally/)
+1. Obtain access to Eclipse Che if you do not already have it, as an individual this can be done by setting up a [local instance of Eclipse Che](https://www.eclipse.dev/che/docs/stable/administration-guide/installing-che-locally/)
     - You can use `minikube` to run your cluster locally, follow [these](https://minikube.sigs.k8s.io/docs/start/) steps to get started
     - An alternative is to use the [Eclipse Che hosted by Red Hat](https://developers.redhat.com/developer-sandbox/ide), see 
-    [the corresponding guide](https://www.eclipse.org/che/docs/stable/hosted-che/hosted-che/) in Eclipse Che documentation if this method is used
+    [the corresponding guide](https://www.eclipse.dev/che/docs/stable/hosted-che/hosted-che/) in Eclipse Che documentation if this method is used
 
 2. For this quick start guide, we will create a simple [hello world Express.js](https://expressjs.com/en/starter/hello-world.html) application
 
@@ -206,4 +206,4 @@ start your project, a similar devfile project workspace can be created using the
 - [Devfile Schema](./devfile-schema)
 - [Adding components](./adding-components)
 - [Adding commands](./adding-commands)
-- [Eclipse Che docs](https://www.eclipse.org/che/docs/stable/overview/introduction-to-eclipse-che/)
+- [Eclipse Che docs](https://www.eclipse.dev/che/docs/stable/overview/introduction-to-eclipse-che/)


### PR DESCRIPTION
## What does this PR do / why we need it
Updates instances of `eclipse.org` to use the new domain of `eclipse.dev`. Although Eclipse has this setup to redirect it is affecting our e2e tests.

## Which issue(s) does this PR fix

Fixes https://github.com/devfile/api/issues/1573

## PR acceptance criteria

- [ ] Unit Tests
- [x] E2E Tests
- [ ] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

## How to test changes / Special notes to the reviewer
Should pass e2e tests