### PR TITLE
Add license to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,10 @@ COPY --from=builder --chown=nextjs:0 /app/apps/${PROJECT_NAME}/dist/.next/static
 
 RUN chown -R 1001:0 ./apps/${PROJECT_NAME} && chmod -R g=u ./apps/${PROJECT_NAME}
 
+# Add license
+RUN mkdir -p /licenses
+COPY LICENSE /licenses
+
 USER 1001
 
 EXPOSE 3000


### PR DESCRIPTION
# Description of Changes

Adds our source license for devfile-web to container images built here.

# Related Issue(s)

part of https://github.com/devfile/api/issues/1638

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

# Tests Performed

```sh
cat /licenses/LICENSE
```

Outputted the same contents of [LICENSE](https://github.com/devfile/registry-support/blob/a6907ada9c43f1f29df303dd5e19d8a64164f4f3/LICENSE).

# How To Test
Deploy images to OpenShift (or Kubernetes) using the helm chart and use the console under the containers to check if the licenses are properly added:

```sh
cat /licenses/LICENSE
```

Should output the same contents of [LICENSE](https://github.com/devfile/registry-support/blob/a6907ada9c43f1f29df303dd5e19d8a64164f4f3/LICENSE).
