### PR TITLE
fix(konflux): Match devfile/registry setup for patching schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,14 @@
     ":gitSignOff"
   ],
   "timezone": "America/Toronto",
-  "schedule": ["after 9pm on tuesday and thursday"],
   "enabledManagers": ["tekton"],
+  "packageRules": [
+    {
+      "description": "Schedule Konflux tekton task updates Tuesday and Thursday nights (9 PM - 12 AM)",
+      "matchManagers": ["tekton"],
+      "schedule": ["* 21-23 * * 2,4"]
+    }
+  ],
   "prHourlyLimit": 20,
   "prConcurrentLimit": 10
 }


### PR DESCRIPTION
# Description of Changes
_Summarize the changes you made as part of this pull request._

Change renovate config to match the changes to [devfile/registry](https://github.com/devfile/registry), https://github.com/devfile/registry/pull/555, to specify `tekton` for the patch schedule. Allowing us to scale the renovate config to patch other dependencies under this repository on a different schedule.

This is also to correct the patching cycle as [devfile/registry](https://github.com/devfile/registry) follows the expected Tuesdays and Thursdays after 9pm and before 12am schedule set whereas devfile-web has been following the default Konflux schedule. We need this custom schedule to be followed in order to avoid blocking devfile registry deployments.

# Related Issue(s)
_Link the GitHub/GitLab/JIRA issues that are related to this PR._

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

I ran the following to validate the renovate config file changes:

1. `export RENOVATE_CONFIG_FILE=$(pwd)/renovate.json`
2. `npx --yes --package renovate -- renovate-config-validator`

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._

Ignore warnings to migrate configuration, it appears MintMaker renovate is still using the old configuration specification.
