### PR TITLE
fix: Adjust renovate schedules for wider time windows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,9 @@
   "enabledManagers": ["tekton"],
   "packageRules": [
     {
-      "description": "Schedule Konflux tekton task updates Tuesday and Thursday nights (9 PM - 12 AM)",
+      "description": "Schedule Konflux tekton task updates Tuesday and Thursday nights (7 PM - 2 AM)",
       "matchManagers": ["tekton"],
-      "schedule": ["* 21-23 * * 2,4"]
+      "schedule": ["* 19-23,0-2 * * 2,4"]
     }
   ],
   "prHourlyLimit": 20,


### PR DESCRIPTION
# Description of Changes

Adjust the time windows for renovate PRs to be between 7pm-2am EST to cover more of the Konflux mintmaker renovate run schedule.

# Related Issue(s)

https://github.com/devfile/api/issues/1716

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._


# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._
