### PR TITLE
fix: add the initial step for the devfile registry guide

### DIFF
--- a/libs/docs/src/docs/no-version/building-a-custom-devfile-registry.md
+++ b/libs/docs/src/docs/no-version/building-a-custom-devfile-registry.md
@@ -69,12 +69,14 @@ your cloud or cluster to form the devfile registry.
 
 ### Procedure
 
-1. Navigate to the `build-tools/` directory that contains the registry build scripts (for example, `devfile/registry-support/build-tools`), where `build_image.sh` is located.
+1. Clone the [devfile/registry-support](https://github.com/devfile/registry-support) repository.
 
-2. Run `./build_image.sh <path-to-devfile-registry-folder>` to build a
+2. Navigate to the `build-tools/` directory within the cloned repository where `build_image.sh` is located.
+
+3. Run `./build_image.sh <path-to-devfile-registry-folder>` to build a
     devfile registry repository.
 
-3. In a multi-stage Docker build, add a Dockerfile to your devfile
+4. In a multi-stage Docker build, add a Dockerfile to your devfile
     registry repository. Make sure the Dockerfile contains the
     following:
 
@@ -97,7 +99,7 @@ your cloud or cluster to form the devfile registry.
     COPY --from=builder /build/stacks /stacks
     ```
 
-4. Run `docker build -t devfile-index` to build the devfile registry
+5. Run `docker build -t devfile-index` to build the devfile registry
     into a container image.
 
 The build script builds the index generator, generates the `index.json`


### PR DESCRIPTION
# Description of Changes

Added a missing step in the **manual for building a custom registry** to instruct users to first clone the [`[registry-support](https://github.com/devfile/registry-support)`](https://github.com/devfile/registry-support) repository and navigate to the `build-tools` folder before running the `build_image.sh` script.
This ensures new contributors know where the script is located and can run it successfully.

---

# Related Issue(s)

Fixes: \[devfile/registry#\<ISSUE\_NUMBER>]
(Replace `<ISSUE_NUMBER>` with the actual issue number you are working on)

---

# Acceptance Criteria

<!-- _Check the relevant boxes below_ -->  

* [ ] Unit Tests
* [ ] E2E Tests
* [x] Documentation
  *Update the [[sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation)](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed*

---

# Tests Performed

* Cloned the `registry-support` repository locally.
* Navigated to `build-tools` and successfully ran `./build_image.sh` using a sample registry content directory to confirm the steps work as expected.

---

# How To Test

1. Open the updated documentation page for building a custom registry.
2. Follow the new **Step 1** (clone `registry-support` and `cd` into `build-tools`).
3. Run the `./build_image.sh <path-to-registry-content>` command.
4. Verify that the image is built successfully without any missing-file errors.

---

# Notes To Reviewer

This is a documentation-only change aimed at improving clarity for new contributors.
No code, configuration, or functionality is affected.