### PR TITLE
chore: update Konflux tekton patch schedule to weekends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,9 @@
   "enabledManagers": ["tekton"],
   "packageRules": [
     {
-      "description": "Schedule Konflux tekton task updates Tuesday and Thursday nights (7 PM - 2 AM)",
+      "description": "Schedule Konflux tekton task updates Saturdays after 5 AM",
       "matchManagers": ["tekton"],
-      "schedule": ["* 19-23,0-2 * * 2,4"]
+      "schedule": ["* 5-23 * * 6"]
     }
   ],
   "prHourlyLimit": 20,


### PR DESCRIPTION
# Description of Changes

The [Konflux Documentation](https://konflux-ci.dev/docs/mintmaker/user/#scheduling) states that the Konflux patching only happens on Saturdays after 5AM. Given this seems to be enforced, we'll need to update our Konflux patching schedule across our Devfile Registry repositories to run MintMaker Renovate to patch Konflux on that schedule.

# Related Issue(s)

https://github.com/devfile/api/issues/1779

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation
_Update the [sidebar](https://github.com/devfile/devfile-web/tree/main/apps/landing-page#configuring-navigation) if there is a new file added or an existing filename is changed_

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._


# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated update schedule for Tekton Manager tasks.
  * Renovate will now run throughout Sundays and Saturdays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->